### PR TITLE
FAQ page and FAQ component

### DIFF
--- a/components/FAQ/faq.module.scss
+++ b/components/FAQ/faq.module.scss
@@ -1,0 +1,51 @@
+$color: #36bbcd; //Color used in the header's bottom bar.
+
+//Holds the question and when click will display the answer.
+.accordion{
+    width: 100%;
+    padding: 0.5rem;
+    text-align:left;
+    background:white;
+    border: none;
+    cursor: pointer;
+    font-size: 1.2rem;
+    position:relative;
+    transition:0.4s;
+    display:flex;
+    flex-direction:row;
+    align-items:center;
+    &:after{
+        content: '\25B6'; //Unicode for right-facing triangle
+        position:absolute;
+        width:20px;
+        height:20px;
+        right:0;
+        font-size: 12px;
+        color: $color;
+        transition: 0.2s ease;
+    }
+}
+
+
+//When the accordion is clicked, the triangle is rotated downwards.
+.active{
+    &::after{
+        transform: rotate(90deg);
+        transform-origin: center left;
+    }
+}
+
+.visible{
+    max-height: 35px;
+    transition: max-height 0.2s ease-out;
+    & > p{
+        padding: 0.5rem;
+        margin: 0;
+    }
+}
+
+.collapsed{
+    max-height:0;
+    transition: max-height 0.2s ease-in;
+    overflow:hidden;
+}

--- a/components/FAQ/index.tsx
+++ b/components/FAQ/index.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from "react";
+import styles from "./faq.module.scss";
+
+interface Props {
+  question: string; //Pass in question as a prop
+  children: React.ReactNode; //Children would be the answer to the question
+}
+
+const FAQ: React.FC<Props> = ({ question, children }) => {
+  const [collapsed, setCollapsed] = useState(true); //Clicking the button will adjust the maximum height of the question, which makes it slide open
+  return (
+    <section>
+      <button
+        className={`${styles["accordion"]} ${
+          collapsed ? "" : styles["active"]
+        }`}
+        onClick={() => setCollapsed(!collapsed)}
+      >
+        {question}
+      </button>
+      <div className={collapsed ? styles["collapsed"] : styles["visible"]}>
+        <p>{children}</p>
+      </div>
+    </section>
+  );
+};
+export default FAQ;

--- a/pages/faq/index.tsx
+++ b/pages/faq/index.tsx
@@ -1,0 +1,27 @@
+import { NextPage } from "next";
+import Header from "components/header";
+import Footer from "components/footer";
+import FAQ from "components/FAQ";
+const Home: NextPage = () => {
+  return (
+    <div className="container">
+      <main>
+        <Header />
+        <div className="wrapper">
+          <FAQ question="Question 1">Answer to question 1...</FAQ>
+          <FAQ question="Question 2">Answer to question 2...</FAQ>
+          <FAQ question="Question 3">Answer to question 3...</FAQ>
+        </div>
+        <Footer />
+      </main>
+      <style jsx>{`
+        .container,
+        .wrapper {
+          min-height: 100vh;
+        }
+      `}</style>
+    </div>
+  );
+};
+
+export default Home;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2102,7 +2102,7 @@ camelcase@5.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
   integrity sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==
 
-camelcase@5.3.1, camelcase@^5.3.1:
+camelcase@5.3.1, camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
@@ -5863,6 +5863,13 @@ react-dom@16.13.1:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.19.1"
+
+react-icons@^3.11.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-3.11.0.tgz#2ca2903dfab8268ca18ebd8cc2e879921ec3b254"
+  integrity sha512-JRgiI/vdF6uyBgyZhVyYJUZAop95Sy4XDe/jmT3R/bKliFWpO/uZBwvSjWEdxwzec7SYbEPNPck0Kff2tUGM2Q==
+  dependencies:
+    camelcase "^5.0.0"
 
 react-is@16.13.1, react-is@^16.3.2, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"


### PR DESCRIPTION
In this PR I've created the FAQ Component and a FAQ page. Because there's no design for the FAQ page yet on the figma, the page currently contains the FAQ component, the header, and the footer. The FAQ component is designed after the accordion link that was in the Linear issue. It currently looks like this:
![Screenshot from 2020-10-12 07-14-33](https://user-images.githubusercontent.com/25257772/95745395-9f0dbe00-0c5a-11eb-810e-df7775ab0a95.png)
Clicking on the question will slide open the answer:
![Screenshot from 2020-10-12 07-13-41](https://user-images.githubusercontent.com/25257772/95745444-b6e54200-0c5a-11eb-9651-cdea14d29914.png)

Please let me know if I need to make any changes.
