### PR TITLE
Added Capabilities to get region of user

### DIFF
--- a/components/HomeChapters/index.tsx
+++ b/components/HomeChapters/index.tsx
@@ -1,7 +1,19 @@
 import React, { useState } from "react";
 import style from "./style.module.scss";
+import { getRegion } from "utils/helpers";
 
 const HomeChapters: React.FC = () => {
+  const [region, setRegion] = React.useState("unknown");
+
+  React.useEffect(() => {
+    if (navigator) {
+      navigator.geolocation.getCurrentPosition((pos: Position) => {
+        const [lat, long] = [pos.coords.latitude, pos.coords.longitude];
+        setRegion(getRegion(lat, long));
+      });
+    }
+  });
+
   return (
     <div className={style.parentContainer}>
       <h2 className={style.title}>Chapters In Your Region</h2>

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -1,3 +1,9 @@
+/**
+ * Takes in coordinates and returns the US region
+ * @param latitude
+ * @param longitude
+ * @returns {string} A string representation of the US region based on the given coordinates
+ */
 export function getRegion(latitude: number, longitude: number): string {
   if (
     longitude < -106.045228 &&

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -1,0 +1,17 @@
+export function getRegion(latitude: number, longitude: number): string {
+  if (
+    longitude < -106.045228 &&
+    longitude > -124.551016 &&
+    latitude < 49.019984
+  ) {
+    return "west";
+  } else if (latitude <= 39.11542 && latitude > 24 && longitude < -59.305383) {
+    return "south";
+  } else if (longitude < -80.483568 && latitude < 49.024915) {
+    return "midwest";
+  } else if (longitude <= -59.305383 && latitude > 39.11542) {
+    return "northeast";
+  }
+
+  return "unknown";
+}


### PR DESCRIPTION
- In the HomeChapter Component, I have added a state for the region that the user is in that can be used to selectively display chapters in the list (not implemented).

- Added Helper: `getRegion` to use to get a string representation of US region from coordinates

- The user is prompted by the browser for location info for the first visit onto the site