### PR TITLE
Officers Carousel & Basic Chapters Page

### DIFF
--- a/components/OfficerCarousel/index.tsx
+++ b/components/OfficerCarousel/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { Officer } from 'utils/types'
+import styles from './style.module.scss';
+
+interface Props {
+  officers: Officer[];
+}
+
+const OfficerCarouselComp: React.FC<Props> = ({ officers }) => {
+  return (
+    <div className={styles.container}>
+      <p>Officers: Test { JSON.stringify(officers) }</p>
+    </div>
+  );
+};
+
+export default OfficerCarouselComp;

--- a/components/OfficerCarousel/index.tsx
+++ b/components/OfficerCarousel/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Officer } from 'utils/types'
 import styles from './style.module.scss';
 
@@ -7,20 +7,69 @@ interface Props {
 }
 
 const OfficerCarouselComp: React.FC<Props> = ({ officers }) => {
+  const [officer, setOfficer] = useState({
+    id: officers[0]._id,
+    name: officers[0].name,
+    role: officers[0].role,
+    bio: officers[0].bio,
+    url: officers[0].picture?.url,
+    delay: 3000
+  });
+
+  const buttons = officers.map((officerObj, i) => {
+    let btnClass = "";
+    if (officerObj._id == officer.id) {
+      btnClass = styles.active;
+    }
+
+    return (
+      <button onClick={() => setOfficerInfo(i, 10000)} className={btnClass} key={JSON.stringify(officerObj._id)}></button>
+    );
+  });
+
+  const setOfficerInfo = (num: any, changeDelay: number) => {
+    setOfficer({
+      id: officers[num]._id,
+      name: officers[num].name,
+      role: officers[num].role,
+      bio: officers[num].bio,
+      url: officers[num].picture?.url,
+      delay: changeDelay
+    });
+  }
+
+  const change = () => {
+    for (let i = 0; i < officers.length; i++)
+    {
+      if (officers[i]._id == officer.id)
+      {
+        // Switch to next officer.
+        if (i == officers.length-1) { setOfficerInfo(0, 3000); }
+        else { setOfficerInfo(i+1, 3000); }
+
+        break;
+      }
+    }
+  }
+
+  useEffect(() => {
+    const timeout = setTimeout(() => change(), officer.delay);
+    return () => clearTimeout(timeout);
+  }, [officer.id]);
+
   return (
     <div className={styles.container}>
       <div className={styles.imgContainer}>
-        <img src={officers[0].picture?.url} />
-        <img src={officers[0].picture?.url} />
+        <img src={officer.url} />
+        <img src={officer.url} />
       </div>
       <div className={styles.infoContainer}>
-        <h1>{officers[0].name}</h1>
-        <h2>{officers[0].role}</h2>
-        <p>{officers[0].bio}</p>
+        <h1>{officer.name}</h1>
+        <h2>{officer.role}</h2>
+        <p>{officer.bio}</p>
 
         <div className={styles.btnContainer}>
-          <button className={styles.active}></button>
-          <button></button>
+          {buttons}
         </div>
       </div>
     </div>

--- a/components/OfficerCarousel/index.tsx
+++ b/components/OfficerCarousel/index.tsx
@@ -9,7 +9,20 @@ interface Props {
 const OfficerCarouselComp: React.FC<Props> = ({ officers }) => {
   return (
     <div className={styles.container}>
-      <p>Officers: Test { JSON.stringify(officers) }</p>
+      <div className={styles.imgContainer}>
+        <img src={officers[0].picture?.url} />
+        <img src={officers[0].picture?.url} />
+      </div>
+      <div className={styles.infoContainer}>
+        <h1>{officers[0].name}</h1>
+        <h2>{officers[0].role}</h2>
+        <p>{officers[0].bio}</p>
+
+        <div className={styles.btnContainer}>
+          <button className={styles.active}></button>
+          <button></button>
+        </div>
+      </div>
     </div>
   );
 };

--- a/components/OfficerCarousel/index.tsx
+++ b/components/OfficerCarousel/index.tsx
@@ -13,20 +13,65 @@ const OfficerCarouselComp: React.FC<Props> = ({ officers }) => {
     role: officers[0].role,
     bio: officers[0].bio,
     url: officers[0].picture?.url,
-    delay: 3000
+    // Add 1 to distinguish default/page load.
+    delay: 4001
   });
 
+  const images = officers.map((officerObj) => {
+    let wrapperClass;
+    // Initial load, default officer: no translation nor animation.
+    if (officerObj._id == officer.id && officer.delay == 4001) { wrapperClass = ""; }
+    // Next/selected officer: slide into view animation.
+    else if (officerObj._id == officer.id) { wrapperClass = styles.show; }
+    // Initial load, non-default officer: translate out of view without animation.
+    else if (officer.delay == 4001) { wrapperClass = styles.hidden; }
+    // Previously shown officer: slide out of view animation.
+    else { wrapperClass = styles.hide; }
+
+    return (
+      <div className={wrapperClass} key={JSON.stringify(officerObj._id)}>
+        <img src={officerObj.picture?.url} />
+        <img src={officerObj.picture?.url} />
+      </div>
+    );
+  });
+
+  // Name, Role, Bio elements
+  const info = () => {
+    // Randomized key so ReactJS will replay transition animation.
+    let rand = Math.floor(Math.random() * 999999999);
+    return (
+      <div className={styles.wrapper} key={rand}>
+        <h1>{officer.name}</h1>
+        <h2>{officer.role}</h2>
+        <p>{officer.bio}</p>
+      </div>
+    );
+  };
+
+  // Carousel button selectors.
   const buttons = officers.map((officerObj, i) => {
     let btnClass = "";
     if (officerObj._id == officer.id) {
       btnClass = styles.active;
     }
-
-    return (
-      <button onClick={() => setOfficerInfo(i, 10000)} className={btnClass} key={JSON.stringify(officerObj._id)}></button>
-    );
+    
+    if (officers.length > 1)
+    {
+      return (
+        // When user manually changes carousel, increase auto change delay to allow user to focus on selected content longer.
+        <button onClick={() => setOfficerInfo(i, 10000)} className={btnClass} key={JSON.stringify(officerObj._id)}></button>
+      );
+    } else
+    {
+      // If there is only one officer, disable changing carousel.
+      return (
+        <button className={btnClass} key={JSON.stringify(officerObj._id)}></button>
+      );
+    }
   });
 
+  // Change carousel's shown officer to next/selected.
   const setOfficerInfo = (num: any, changeDelay: number) => {
     setOfficer({
       id: officers[num]._id,
@@ -38,36 +83,39 @@ const OfficerCarouselComp: React.FC<Props> = ({ officers }) => {
     });
   }
 
-  const change = () => {
+  // Change to the next officer in the array.
+  const autoChange = () => {
     for (let i = 0; i < officers.length; i++)
     {
       if (officers[i]._id == officer.id)
       {
-        // Switch to next officer.
-        if (i == officers.length-1) { setOfficerInfo(0, 3000); }
-        else { setOfficerInfo(i+1, 3000); }
+        // Switch to next officer with default change delay.
+        if (i == officers.length-1) { setOfficerInfo(0, 4000); }
+        else { setOfficerInfo(i+1, 4000); }
 
         break;
       }
     }
   }
 
+  // Runs when officer.id is updated, aka when the officer is first loaded or changed.
   useEffect(() => {
-    const timeout = setTimeout(() => change(), officer.delay);
-    return () => clearTimeout(timeout);
+    if (officers.length > 1)
+    {
+      // After carousel is changed (automatically or manually), wait officer.delay ms to change again.
+      const timeout = setTimeout(() => autoChange(), officer.delay);
+      return () => clearTimeout(timeout);
+    }
   }, [officer.id]);
 
+  // Carousel elements
   return (
     <div className={styles.container}>
       <div className={styles.imgContainer}>
-        <img src={officer.url} />
-        <img src={officer.url} />
+        {images}
       </div>
       <div className={styles.infoContainer}>
-        <h1>{officer.name}</h1>
-        <h2>{officer.role}</h2>
-        <p>{officer.bio}</p>
-
+        {info()}
         <div className={styles.btnContainer}>
           {buttons}
         </div>

--- a/components/OfficerCarousel/style.module.scss
+++ b/components/OfficerCarousel/style.module.scss
@@ -1,88 +1,89 @@
 /* Officer carousel container */
 div.container {
-    background-color: rgb(148, 144, 148);
-    width: 100%;
-    display: grid;
-    @media (min-width: 860px) { grid-template-columns: 50% 50%; }
-    @media (max-width: 860px) { grid-template-columns: repeat(auto-fill, 100%); }
-    div.imgContainer, div.infoContainer {
-        overflow: hidden;
-    }
+  background-color: rgb(148, 144, 148);
+  width: 100%;
+  display: grid;
+  @media (min-width: 860px) { grid-template-columns: 50% 50%; }
+  @media (max-width: 860px) { grid-template-columns: repeat(auto-fill, 100%); }
+  div.imgContainer, div.infoContainer {
+    overflow: hidden;
+  }
 }
 /* Officer picture container */
 div.container div.imgContainer {
-    @media (min-width: 860px) { height: 475px; }
-    @media (max-width: 860px) { height: 350px; }
-    position: relative;
-    background-color: #D7D7D7;
-    img {
-        position: absolute;
-        left: 0;
-        right: 0;
-        margin: auto;
-    }
-    /* Blurred officer picture to fill potential whitespace */
-    img:nth-of-type(1) {
-        width: 100%;
-        height: 100%;
-        filter: blur(8px);
-        -webkit-filter: blur(8px);
-    }
-    /* Officer picture */
-    img:nth-of-type(2) {
-        width: auto;
-        height: 100%;
-    }
+  @media (min-width: 860px) { height: 475px; }
+  @media (max-width: 860px) { height: 350px; }
+  position: relative;
+  background-color: #D7D7D7;
+  img {
+    position: absolute;
+    left: 0;
+    right: 0;
+    margin: auto;
+  }
+  /* Blurred officer picture to fill potential whitespace */
+  img:nth-of-type(1) {
+    width: 100%;
+    height: 100%;
+    filter: blur(8px);
+    -webkit-filter: blur(8px);
+  }
+  /* Officer picture */
+  img:nth-of-type(2) {
+    width: auto;
+    height: 100%;
+  }
 }
 /* Officer information container */
 div.container div.infoContainer {
-    height: 100%;
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    text-align: left;
-    background-color: #E9E9E9;
-    /* Name, role, bio */
-    h1, h2, p {
-        width: 80%;
-        margin: 0;
-        padding: 0;
-    }
-    h1 {
-        font-weight: 600;
-        @media (min-width: 860px) { padding-top: 140px; }
-        @media (max-width: 860px) { padding-top: 25px; }
-    }
-    h2 {
-        font-weight: 500;
-        font-style: italic;
-    }
-    p {
-        margin-top: 25px;
-        max-height: 175px;
-        overflow-y: auto;
-        @media (min-width: 860px) { padding-bottom: 0; }
-        @media (max-width: 860px) { margin-bottom: 70px; }
-    }
+  height: 100%;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: left;
+  background-color: #E9E9E9;
+  /* Name, role, bio */
+  h1, h2, p {
+    width: 80%;
+    margin: 0;
+    padding: 0;
+  }
+  h1 {
+    font-weight: 600;
+    @media (min-width: 860px) { padding-top: 140px; }
+    @media (max-width: 860px) { padding-top: 25px; }
+  }
+  h2 {
+    font-weight: 500;
+    font-style: italic;
+  }
+  p {
+    margin-top: 25px;
+    max-height: 175px;
+    overflow-y: auto;
+    @media (min-width: 860px) { padding-bottom: 0; }
+    @media (max-width: 860px) { margin-bottom: 70px; }
+  }
 }
 /* Carousel selectors container */
 div.container div.infoContainer div.btnContainer {
-    width: 100%;
-    height: 25px;
-    position: absolute;
-    bottom: 25px;
-    left: 0;
-    text-align: center;
-    /* Carousel selectors */
-    button {
-        width: 12.5px;
-        height: 12.5px;
-        background-color: #FFFFFF;
-        margin-right: 7.5px;
-        border: none;
-        border-radius: 50%;
-    }
-    button:hover { cursor: pointer; }
-    button.active { background-color: #707070; }
+  width: 100%;
+  height: 25px;
+  position: absolute;
+  bottom: 25px;
+  left: 0;
+  text-align: center;
+  /* Carousel selectors */
+  button {
+    width: 12.5px;
+    height: 12.5px;
+    background-color: #FFFFFF;
+    margin-right: 7.5px;
+    border: none;
+    border-radius: 50%;
+  }
+  button:hover { cursor: pointer; }
+  button:focus { outline: none; }
+  button.active { background-color: #707070; }
 }

--- a/components/OfficerCarousel/style.module.scss
+++ b/components/OfficerCarousel/style.module.scss
@@ -1,0 +1,88 @@
+/* Officer carousel container */
+div.container {
+    background-color: rgb(148, 144, 148);
+    width: 100%;
+    display: grid;
+    @media (min-width: 860px) { grid-template-columns: 50% 50%; }
+    @media (max-width: 860px) { grid-template-columns: repeat(auto-fill, 100%); }
+    div.imgContainer, div.infoContainer {
+        overflow: hidden;
+    }
+}
+/* Officer picture container */
+div.container div.imgContainer {
+    @media (min-width: 860px) { height: 475px; }
+    @media (max-width: 860px) { height: 350px; }
+    position: relative;
+    background-color: #D7D7D7;
+    img {
+        position: absolute;
+        left: 0;
+        right: 0;
+        margin: auto;
+    }
+    /* Blurred officer picture to fill potential whitespace */
+    img:nth-of-type(1) {
+        width: 100%;
+        height: 100%;
+        filter: blur(8px);
+        -webkit-filter: blur(8px);
+    }
+    /* Officer picture */
+    img:nth-of-type(2) {
+        width: auto;
+        height: 100%;
+    }
+}
+/* Officer information container */
+div.container div.infoContainer {
+    height: 100%;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: left;
+    background-color: #E9E9E9;
+    /* Name, role, bio */
+    h1, h2, p {
+        width: 80%;
+        margin: 0;
+        padding: 0;
+    }
+    h1 {
+        font-weight: 600;
+        @media (min-width: 860px) { padding-top: 140px; }
+        @media (max-width: 860px) { padding-top: 25px; }
+    }
+    h2 {
+        font-weight: 500;
+        font-style: italic;
+    }
+    p {
+        margin-top: 25px;
+        max-height: 175px;
+        overflow-y: auto;
+        @media (min-width: 860px) { padding-bottom: 0; }
+        @media (max-width: 860px) { margin-bottom: 70px; }
+    }
+}
+/* Carousel selectors container */
+div.container div.infoContainer div.btnContainer {
+    width: 100%;
+    height: 25px;
+    position: absolute;
+    bottom: 25px;
+    left: 0;
+    text-align: center;
+    /* Carousel selectors */
+    button {
+        width: 12.5px;
+        height: 12.5px;
+        background-color: #FFFFFF;
+        margin-right: 7.5px;
+        border: none;
+        border-radius: 50%;
+    }
+    button:hover { cursor: pointer; }
+    button.active { background-color: #707070; }
+}

--- a/components/OfficerCarousel/style.module.scss
+++ b/components/OfficerCarousel/style.module.scss
@@ -5,9 +5,7 @@ div.container {
   display: grid;
   @media (min-width: 860px) { grid-template-columns: 50% 50%; }
   @media (max-width: 860px) { grid-template-columns: repeat(auto-fill, 100%); }
-  div.imgContainer, div.infoContainer {
-    overflow: hidden;
-  }
+  div.imgContainer, div.infoContainer { overflow: hidden; }
 }
 /* Officer picture container */
 div.container div.imgContainer {
@@ -15,11 +13,36 @@ div.container div.imgContainer {
   @media (max-width: 860px) { height: 350px; }
   position: relative;
   background-color: #D7D7D7;
+}
+/* Officer picture wrapper (contains picture and blurred background) */
+div.container div.imgContainer div {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  /* Slide animations */
+  &.hidden {
+    opacity: 0.0;
+    animation: hideOfficer 0.1s linear forwards;
+  }
+  &.show {
+    transform: translateX(100%);
+    animation: showOfficer 0.75s ease-out forwards;
+  }
+  &.hide { animation: hideOfficer 0.75s ease-out forwards; }
+  @keyframes showOfficer {
+    from { transform: translateX(100%); }
+    to { transform: translateX(0); }
+  }
+  @keyframes hideOfficer {
+    to { transform: translateX(-100%); }
+  }
+  /* General styling for both picture and background */
   img {
     position: absolute;
     left: 0;
     right: 0;
     margin: auto;
+    opacity: 1;
   }
   /* Blurred officer picture to fill potential whitespace */
   img:nth-of-type(1) {
@@ -43,9 +66,25 @@ div.container div.infoContainer {
   align-items: center;
   text-align: left;
   background-color: #E9E9E9;
+}
+/* Name, role, bio wrapper */
+div.container div.infoContainer div.wrapper {
+  width: 80%;
+  /* Slide up transition animation. */
+  animation: transitionText 0.75s ease-out forwards;
+  @keyframes transitionText {
+    0% {
+      opacity: 0.0;
+      transform: translateY(30px);
+    }
+    15% { opacity: 0.0; }
+    100% {
+      opacity: 1.0;
+      transform: translateY(0);
+    }
+  }
   /* Name, role, bio */
   h1, h2, p {
-    width: 80%;
     margin: 0;
     padding: 0;
   }
@@ -82,6 +121,7 @@ div.container div.infoContainer div.btnContainer {
     margin-right: 7.5px;
     border: none;
     border-radius: 50%;
+    transition: background-color 0.35s;
   }
   button:hover { cursor: pointer; }
   button:focus { outline: none; }

--- a/pages/chapters/[name].tsx
+++ b/pages/chapters/[name].tsx
@@ -53,11 +53,10 @@ const ChapterPage: NextPage<Props> = ({ chapter, officers }) => {
         </div>
         <div className="chapterOfficerParent bodySection">
           <h2>Meet the Team</h2>
-          {/* <OfficerCarouselComp /> */}
+          <OfficerCarouselComp officers={officers} />
         </div>
       </div>
       
-      <OfficerCarouselComp officers={officers}/>
       <ChapterComp chapter={chapter}/>
       
       <Footer />

--- a/pages/chapters/[name].tsx
+++ b/pages/chapters/[name].tsx
@@ -1,8 +1,10 @@
 import Header from "components/Header";
 import Footer from "components/Footer";
 import ChapterComp from "components/Chapter";
+import OfficerCarouselComp from "components/OfficerCarousel";
 import { getChapters } from "requests/Chapter";
-import { Chapter } from 'utils/types';
+import { getOfficers } from "requests/Officer";
+import { Chapter, Officer } from 'utils/types';
 import { NextPage, NextPageContext } from 'next';
 import { FaMapMarkerAlt } from "react-icons/fa";
 import errors from 'utils/errors';
@@ -12,10 +14,11 @@ import Head from "next/head";
 // We can get that param with useRouter(), but its also given in the context
 
 interface Props {
-  chapter: Chapter;
+  chapter: Chapter,
+  officers: Officer[],
 }
 
-const ChapterPage: NextPage<Props> = ({ chapter }) => {
+const ChapterPage: NextPage<Props> = ({ chapter, officers }) => {
 
   //Replace any underscores in the chapter name with spaces
   var cleanName = chapter.name?.replace(/_/g, " ");
@@ -50,9 +53,11 @@ const ChapterPage: NextPage<Props> = ({ chapter }) => {
         </div>
         <div className="chapterOfficerParent bodySection">
           <h2>Meet the Team</h2>
+          {/* <OfficerCarouselComp /> */}
         </div>
       </div>
-
+      
+      <OfficerCarouselComp officers={officers}/>
       <ChapterComp chapter={chapter}/>
       
       <Footer />
@@ -193,8 +198,19 @@ ChapterPage.getInitialProps = async ( context: NextPageContext ) => {
     throw new Error(errors.GENERIC_ERROR);
   }
 
+  let officerQuery: Officer = new Object;
+  officerQuery.chapter = chapter.name;
+
+  var officers: Officer[] = await getOfficers(officerQuery);
+  if (!(officers.length > 0))
+  {
+    // TODO route to an error page
+    throw new Error(errors.GENERIC_ERROR);
+  }
+
   return {
       chapter: chapter,
+      officers: officers
   }
 }
 

--- a/pages/chapters/[name].tsx
+++ b/pages/chapters/[name].tsx
@@ -1,9 +1,12 @@
+import Header from "components/Header";
 import Footer from "components/Footer";
 import ChapterComp from "components/Chapter";
 import { getChapters } from "requests/Chapter";
 import { Chapter } from 'utils/types';
 import { NextPage, NextPageContext } from 'next';
+import { FaMapMarkerAlt } from "react-icons/fa";
 import errors from 'utils/errors';
+import Head from "next/head";
 
 // When routing here we have a chapter name we can get from the url name
 // We can get that param with useRouter(), but its also given in the context
@@ -13,11 +16,162 @@ interface Props {
 }
 
 const ChapterPage: NextPage<Props> = ({ chapter }) => {
+
+  //Replace any underscores in the chapter name with spaces
+  var cleanName = chapter.name?.replace(/_/g, " ");
+  //Make the first letter of the region name capital
+  var cleanRegion = chapter.region?.charAt(0).toUpperCase().concat(chapter.region.substr(1));
+
   return(
     <div>
-      <p> hello from the main page </p>
+      
+      <Head>
+        <title>{cleanName} Chapter | MindVersity | A peer mental health network.</title>
+        <link rel="icon" href="../favicon.ico" />
+      </Head>
+      
+      <Header />
+
+      <div className="hero" style={{backgroundImage: "url('/rutgers-placeholder.jpg')"}}>
+        <div className="heroOverlay">
+          <div className="heroText">
+            <h1>{cleanName}</h1>
+            <h2><FaMapMarkerAlt className="locationIcon" /> {cleanRegion}</h2>
+          </div>
+        </div>
+      </div>
+     
+      <div className="bodyContent">
+        <div className="aboutTextParent bodySection">
+          <h2>About</h2>
+          <p className="aboutText">
+            {chapter.description}
+          </p>
+        </div>
+        <div className="chapterOfficerParent bodySection">
+          <h2>Meet the Team</h2>
+        </div>
+      </div>
+
       <ChapterComp chapter={chapter}/>
-      <Footer/>
+      
+      <Footer />
+
+      <style jsx>{`
+      .hero{
+        width: 100%;
+        height: 50vh;
+        position: relative;
+        background-image: url('journal-hero.jpeg');
+        background-size: cover;
+        background-position: center;
+      }
+
+      .heroOverlay{
+        width: 100%;
+        height: 100%;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        z-index: 2;
+        background-color: rgba(215, 215, 215, 0.70);
+      }
+
+      .heroText{
+        position: relative;
+        display: block;
+        top: 50%;
+        transform: translateY(-50%);
+        padding: 0px 40px;
+      }
+
+      h1{
+        position: relative;
+        display: block;
+        color: #503E8C;
+        font-size: 46px;
+        font-weight: bold;
+        padding-bottom: 0px;
+        margin-bottom: 0px;
+      }
+
+      .heroText h2{
+        font-weight: normal;
+        margin-top: 0;
+        padding-top: 20px;
+        padding-left: 40px
+      }
+
+      .locationIcon{
+        color: #707070;
+      }
+
+      .bodyContent{
+        width: auto;
+        height: auto;
+        position: relative;
+        display: block;
+        padding: 60px;
+      }
+
+      .bodySection{
+        width: auto;
+        height: auto;
+        position: relative;
+        display: block;
+        padding: 20px 0px;
+      }
+
+      .aboutTextParent h2{
+        position: relative;
+        display: block;
+        text-align: left;
+        font-size: 38px;
+        color: #707070;
+      }
+
+      @media screen and (min-width: 770px){
+        .aboutText{
+          font-size: 20px;
+          color: #707070;
+          width: 40%;
+        }  
+      }
+
+      @media screen and (max-width: 770px){
+        .aboutText{
+          font-size: 20px;
+          color: #707070;
+          width: 100%;
+        }  
+      }
+      
+      .chapterOfficerParent h2{
+        position: relative;
+        display: block;
+        text-align: left;
+        font-size: 38px;
+        color: black;
+      }
+
+	  `}</style>
+
+	  <style jsx global>{`
+      html,
+      body {
+      padding: 0;
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
+        Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue,
+        sans-serif;
+      }
+
+      * {
+      box-sizing: border-box;
+      }
+  	`}</style>
     </div>
   );
 };
@@ -40,9 +194,8 @@ ChapterPage.getInitialProps = async ( context: NextPageContext ) => {
   }
 
   return {
-    chapter: chapter,
+      chapter: chapter,
   }
 }
-
 
 export default ChapterPage;


### PR DESCRIPTION
Created officers carousel to display the various officers for each chapter. The carousel changes officers automatically every four seconds. A user can also manually select an officer to view by clicking the corresponding circular button; once selected, the carousel will not automatically change for another ten seconds to allow the user to view their selection longer.

![carousel](https://user-images.githubusercontent.com/54458982/100825804-df9de280-3426-11eb-9d0a-579a56669879.gif)

When the browser hits a certain breakpoint, the text portion moves below the image portion:

![mobile](https://user-images.githubusercontent.com/54458982/100825176-75d10900-3425-11eb-94a4-2458332b18e6.PNG)

I implemented this carousel into @rluberto 's basic chapters page that was pushed onto this branch:

![basicchapterspage](https://user-images.githubusercontent.com/54458982/100825232-97ca8b80-3425-11eb-898a-a94735edbcbf.PNG)
