### PR TITLE
Create Post Frontend and Backend

### DIFF
--- a/components/CreateJournalEntry/create.module.scss
+++ b/components/CreateJournalEntry/create.module.scss
@@ -35,8 +35,9 @@ $dark-purple: #503E8C;
     width: 100%;
     position:relative;
     height: 600px;
-    background: $light-purple;
     display:flex;
+    background-size: 100% 600px !important;
+    background-repeat: no-repeat;
     flex-direction:column;
     align-items:center;
 }
@@ -111,4 +112,15 @@ $dark-purple: #503E8C;
     color:white;
     margin:10px;
     border-radius:10px;
+}
+
+
+.error{
+    text-align:center;
+    align-self:center;
+    padding:0.5rem;
+    background:#ffafa6;
+    border-radius: 10px;
+    width:50%;
+    color: #540901;
 }

--- a/components/CreateJournalEntry/create.module.scss
+++ b/components/CreateJournalEntry/create.module.scss
@@ -40,6 +40,7 @@ $dark-purple: #503E8C;
     flex-direction:column;
     align-items:center;
 }
+
 .icon-container{
     width:100%;
     height:100%;
@@ -48,6 +49,7 @@ $dark-purple: #503E8C;
     align-items:center;
     justify-content:center;
 }
+
 .image-icon{
     width:100px;
     height:100px;
@@ -61,3 +63,52 @@ $dark-purple: #503E8C;
     opacity:0;
 }
 
+.text-container{
+    display:flex;
+    flex-direction:column;
+    margin-top:10px;
+    & > input, & > label, & > .editor{
+        width:90%;
+        align-self:center;
+        margin:5px;
+        border:none;
+        font-size:1.1rem;
+    }
+    & > input{
+        background:#E7E7E7;
+        padding:0.5rem;
+        border-radius:10px;
+    }
+    & > label{
+        font-size: 1.4rem;
+    }
+}
+.select-container{
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    & > span{
+        font-size:1.2rem;
+    }
+}
+
+.category{
+    border:none;
+    background:white;
+    width:min-content;
+    font-size:1rem;
+    color: #545454;
+    text-align:center;
+    margin-left:5px;
+}
+.submit {
+    width:150px;
+    padding:0.5rem;
+    align-self:center;
+    background: $dark-purple;
+    border:none;
+    font-size:1.2rem;
+    color:white;
+    margin:10px;
+    border-radius:10px;
+}

--- a/components/CreateJournalEntry/create.module.scss
+++ b/components/CreateJournalEntry/create.module.scss
@@ -1,0 +1,63 @@
+$light-purple:#EAE0F1;
+$dark-purple: #503E8C;
+
+
+.container{
+    min-height: 100vh;
+    display:flex;
+    flex-direction:column;
+}
+.wrapper{
+    width:80%;
+    align-self:center;
+}
+.breadcrumb{
+    color: black;
+    text-decoration: none;
+    display: flex;
+    flex-direction: row;
+    transition: 0.3s ease;
+    margin-bottom:10px;
+    & > span{
+        margin-left: 10px;
+    }
+    &:hover{
+        color: $dark-purple;
+    }
+}
+
+.create-form{
+    display:flex;
+    flex-direction:column;
+}
+
+.image-container{
+    width: 100%;
+    position:relative;
+    height: 600px;
+    background: $light-purple;
+    display:flex;
+    flex-direction:column;
+    align-items:center;
+}
+.icon-container{
+    width:100%;
+    height:100%;
+    display:flex;
+    flex-direction:column;
+    align-items:center;
+    justify-content:center;
+}
+.image-icon{
+    width:100px;
+    height:100px;
+}
+
+.image-select{
+    position:absolute;
+    width:100%;
+    height:100%;
+    cursor:pointer;
+    opacity:0;
+}
+

--- a/components/CreateJournalEntry/index.tsx
+++ b/components/CreateJournalEntry/index.tsx
@@ -3,6 +3,8 @@ import Link from "next/link";
 import styles from "./create.module.scss";
 import { FaArrowLeft } from "react-icons/fa";
 import {BiImageAdd} from "react-icons/bi";
+import dynamic from "next/dynamic"
+const ReactQuill = dynamic(import('react-quill'), { ssr: false});
 const CreateJournalEntry: React.FC = () => {
     return(
         <section className={styles['container']}>
@@ -20,14 +22,22 @@ const CreateJournalEntry: React.FC = () => {
                         </div>
                         <input type="file" name="image" className={styles['image-select']}/>
                     </div>
-                    <input type="text" name="title" placeholder="Title"/>
-                    <input type="text" name="description" placeholder="Description" />
-
-                    <select name="category" className={styles['category']}>
-                        <option value="">Please select a category</option>
-                        <option value="vent-place">Vent Place</option>
-                        <option value="creative-space">Creative Space</option>
-                    </select>
+                    <div className={styles['text-container']}>
+                        <label htmlFor="title">Title</label>
+                        <input type="text" name="title" placeholder="Title"/>
+                        <label htmlFor="description">Description</label>
+                        <input type="text" name="description" placeholder="Description" />
+                        <label htmlFor="body">Body Paragraph</label>
+                        <ReactQuill theme="snow" className={styles['editor']} placeholder="Enter your journal body here."/>
+                        <div className={styles['select-container']}>
+                            <span>Publish to: </span>
+                            <select name="category" className={styles['category']}>
+                                <option value="">Please select a category</option>
+                                <option value="vent-place">Vent Place</option>
+                                <option value="creative-space">Creative Space</option>
+                            </select>
+                        </div>
+                    </div>
                     <button type="submit" className={styles['submit']}>Publish</button>
                 </form>
             </div>

--- a/components/CreateJournalEntry/index.tsx
+++ b/components/CreateJournalEntry/index.tsx
@@ -121,6 +121,7 @@ const CreateJournalEntry: React.FC = () => {
                     )}
                     <button type="submit" className={styles['submit']}>Publish</button>
                 </form>
+
             </div>
         </section>
     );

--- a/components/CreateJournalEntry/index.tsx
+++ b/components/CreateJournalEntry/index.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import Link from "next/link";
+import styles from "./create.module.scss";
+import { FaArrowLeft } from "react-icons/fa";
+import {BiImageAdd} from "react-icons/bi";
+const CreateJournalEntry: React.FC = () => {
+    return(
+        <section className={styles['container']}>
+            <div className={styles['wrapper']}>
+                <Link href='/journal'>
+                    <a className={styles['breadcrumb']}>
+                        <FaArrowLeft />
+                        <span> Back to all posts</span>
+                    </a>
+                </Link>
+                <form className={styles['create-form']}>
+                    <div className={styles['image-container']}>
+                        <div className={styles['icon-container']}>
+                            <BiImageAdd className={styles['image-icon']}/>
+                        </div>
+                        <input type="file" name="image" className={styles['image-select']}/>
+                    </div>
+                    <input type="text" name="title" placeholder="Title"/>
+                    <input type="text" name="description" placeholder="Description" />
+
+                    <select name="category" className={styles['category']}>
+                        <option value="">Please select a category</option>
+                        <option value="vent-place">Vent Place</option>
+                        <option value="creative-space">Creative Space</option>
+                    </select>
+                    <button type="submit" className={styles['submit']}>Publish</button>
+                </form>
+            </div>
+        </section>
+    );
+};
+
+export default CreateJournalEntry;

--- a/components/CreateJournalEntry/index.tsx
+++ b/components/CreateJournalEntry/index.tsx
@@ -4,8 +4,86 @@ import styles from "./create.module.scss";
 import { FaArrowLeft } from "react-icons/fa";
 import {BiImageAdd} from "react-icons/bi";
 import dynamic from "next/dynamic"
+import {useState} from "react";
 const ReactQuill = dynamic(import('react-quill'), { ssr: false});
+
+interface IFormValues {
+    title?: string,
+    description?: string,
+    image?: File,
+    body?: string,
+    category?: string, 
+    error?: boolean,
+    [key: string]: any, //TypeScript throws a weird error with this. This is set to any for now, but it can be changed later. 
+}
+
+
 const CreateJournalEntry: React.FC = () => {
+    const [values, setValues] = useState({} as IFormValues); //Used to store the various values that will be sent to the backend. 
+    const [imageURL, setImageURL] = useState("");
+
+    //Idea from: https://upmostly.com/tutorials/form-validation-using-custom-react-hooks
+    const handleChange = (e:React.SyntheticEvent) => {
+        e.persist();
+        let target = e.target as HTMLInputElement;
+        if(target != null){
+            if(target.name == "image" && target.files != null){
+                setValues(values => ({...values, [target.name]: target.files[0]}));
+                handleImageURL(target.files[0]);
+            } else {
+                setValues(values => ({...values, [target.name]: target.value}));
+            }
+        }
+    };
+
+    const handleImageURL = (image: File) => {
+        const fr = new FileReader();
+        //If the user cancels their file upload, an error is thrown by NextJS. To fix this, we just check to make sure that a file has been uploaded before doing any URL processing.
+        if(image != null){
+            fr.onloadend = function(e:ProgressEvent<FileReader>) {
+                if(e.target != null){
+                    setImageURL(e.target.result as string);
+                }
+            }
+            fr.readAsDataURL(image);
+        }
+        
+    }
+    const handleQuill = (content, delta, source, editor) => {
+        //If the editor is empty, the only thing in it is a newline character. We don't want to send just newlines to the backend, so we do this.
+        if(editor.getText() != "\n"){
+            if(values.body){
+                delete values.error;
+            }
+            setValues(values => ({...values, ["body"]: editor.getHTML()}));
+        } else {
+            delete values.body;
+        }
+    };
+    const handleSubmit = async (e:React.SyntheticEvent) => {
+        //There's no way to put a required tag on the quill editor, so we just check to make sure there's input in it before submitting.
+        e.preventDefault();
+        if(!values.body){
+            setValues({...values, ["error"]: true});
+        }
+        if(!values.error){
+            const fd = new FormData();
+            let key:string;
+            for(key in values){
+                fd.append(key, values[key]);
+            }
+            const response = await fetch('/api/journal/create', {
+                method: "POST",
+                body: fd,
+            });
+            const data:JSON = await response.json();
+            console.log(data);
+        }
+
+    }
+
+
+
     return(
         <section className={styles['container']}>
             <div className={styles['wrapper']}>
@@ -15,29 +93,32 @@ const CreateJournalEntry: React.FC = () => {
                         <span> Back to all posts</span>
                     </a>
                 </Link>
-                <form className={styles['create-form']}>
-                    <div className={styles['image-container']}>
+                <form className={styles['create-form']} onSubmit={handleSubmit}>
+                    <div className={styles['image-container']} style={imageURL ? {background: `url(${imageURL})`} : {background:'#EAE0F1'} }>
                         <div className={styles['icon-container']}>
                             <BiImageAdd className={styles['image-icon']}/>
                         </div>
-                        <input type="file" name="image" className={styles['image-select']}/>
+                        <input type="file" name="image" className={styles['image-select']} onChange={handleChange} required/>
                     </div>
                     <div className={styles['text-container']}>
                         <label htmlFor="title">Title</label>
-                        <input type="text" name="title" placeholder="Title"/>
+                        <input type="text" name="title" placeholder="Title" onChange={handleChange} value={values.title || ""} required/>
                         <label htmlFor="description">Description</label>
-                        <input type="text" name="description" placeholder="Description" />
+                        <input type="text" name="description" placeholder="Description" onChange={handleChange} value={values.description || ""} required />
                         <label htmlFor="body">Body Paragraph</label>
-                        <ReactQuill theme="snow" className={styles['editor']} placeholder="Enter your journal body here."/>
+                        <ReactQuill theme="snow" className={styles['editor']} placeholder="Enter your journal body here." onChange={handleQuill}/>
                         <div className={styles['select-container']}>
                             <span>Publish to: </span>
-                            <select name="category" className={styles['category']}>
+                            <select name="category" className={styles['category']} onChange={handleChange} required>
                                 <option value="">Please select a category</option>
                                 <option value="vent-place">Vent Place</option>
                                 <option value="creative-space">Creative Space</option>
                             </select>
                         </div>
                     </div>
+                    {values.error && (
+                        <span className={styles['error']}>Please enter a body paragraph.</span>
+                    )}
                     <button type="submit" className={styles['submit']}>Publish</button>
                 </form>
             </div>

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "react-bootstrap": "^1.3.0",
         "react-dom": "16.13.1",
         "react-icons": "^3.11.0",
+        "react-quill": "^1.3.5",
         "sass": "^1.27.0",
         "styled-components": "^5.2.0"
     },

--- a/pages/api/journal/create.ts
+++ b/pages/api/journal/create.ts
@@ -17,12 +17,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         let journalEntry: JournalEntry = fields;
         //In Contentful, Entries store links to Assets (in this case, our Journal Entry images), so we get the asset ID and url for the JournalEntry's image
         journalEntry.image = await uploadImage(files.image);
-        const created = await createJournalEntry(journalEntry);
+        let created = await createJournalEntry(journalEntry);
         if(created){
-            res.status(200).json({message: "Post successfully created!"});
-        } else {
-            res.status(400).json({message: 'Something went wrong. Please try again.'});
+            res.status(200).json({message: "Post creation successful."});
+        } else{ 
+            res.status(400).json({message:"Something went wrong. Please try again."});
         }
-    });
-        
+    }); 
 }

--- a/pages/api/journal/create.ts
+++ b/pages/api/journal/create.ts
@@ -1,0 +1,28 @@
+import { NextApiResponse, NextApiRequest } from "next";
+import formidable from "formidable";
+import {uploadImage, createJournalEntry} from "server/actions/Contentful";
+import {JournalEntry} from "utils/types";
+
+//To get formidable to work, bodyParser has to be turned off. Otherwise, the parse request will never end.
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse){
+    const form = new formidable.IncomingForm();
+    form.parse(req, async (err:string, fields: formidable.Fields ,files: formidable.Files) => { 
+        let journalEntry: JournalEntry = fields;
+        //In Contentful, Entries store links to Assets (in this case, our Journal Entry images), so we get the asset ID and url for the JournalEntry's image
+        journalEntry.image = await uploadImage(files.image);
+        const created = await createJournalEntry(journalEntry);
+        if(created){
+            res.status(200).json({message: "Post successfully created!"});
+        } else {
+            res.status(400).json({message: 'Something went wrong. Please try again.'});
+        }
+    });
+        
+}

--- a/pages/api/journal/get.ts
+++ b/pages/api/journal/get.ts
@@ -1,0 +1,18 @@
+import { NextApiResponse, NextApiRequest } from "next";
+import {getJournalEntriesByReviewStatus} from "server/actions/Contentful";
+//This API route takes in a query from the url. By default, the route will return all entries that have not been reviewed. To get reviewed entries, use the following route: /api/journal/get?reviewed=true
+export default async function handler(req: NextApiRequest, res: NextApiResponse){
+
+    if(req.method == "GET"){
+        let reviewed = false;
+        if(req.query.reviewed){
+           reviewed = (req.query.reviewed === "true") || (req.query.reviewed === "false");
+        }
+        const entries = await getJournalEntriesByReviewStatus(reviewed);
+        if(entries != {}){
+            res.status(200).json(entries);
+        } else {
+            res.status(500).json({message:"Server error."});
+        }
+    }
+}

--- a/pages/api/journal/getByReviewStatus.ts
+++ b/pages/api/journal/getByReviewStatus.ts
@@ -1,12 +1,13 @@
 import { NextApiResponse, NextApiRequest } from "next";
 import {getJournalEntriesByReviewStatus} from "server/actions/Contentful";
-//This API route takes in a query from the url. By default, the route will return all entries that have not been reviewed. To get reviewed entries, use the following route: /api/journal/get?reviewed=true
+//This API route takes in a query from the url. By default, the route will return all entries that have not been reviewed. To get reviewed entries, use the following route: /api/journal/getByReviewStatus?reviewed=true
 export default async function handler(req: NextApiRequest, res: NextApiResponse){
 
     if(req.method == "GET"){
         let reviewed = false;
+        //Req.query.reviewed is a string, but getJournalEntriesByReviewStatus expects a boolean. To make it one, we check if req.query.reviewed === "true". If it is, then we have a boolean review status with true. If not, the boolean status remains false.
         if(req.query.reviewed){
-           reviewed = (req.query.reviewed === "true") || (req.query.reviewed === "false");
+           reviewed = (req.query.reviewed === "true");
         }
         const entries = await getJournalEntriesByReviewStatus(reviewed);
         if(entries != {}){

--- a/pages/journal/create.tsx
+++ b/pages/journal/create.tsx
@@ -6,6 +6,7 @@ import CreateJournalEntry from "components/CreateJournalEntry";
 const Create: NextPage = () => {
     return(
         <main>
+            <link rel="stylesheet" href="//cdn.quilljs.com/1.2.6/quill.snow.css" />
             <Header/>
             <CreateJournalEntry/>
             <Footer/>

--- a/pages/journal/create.tsx
+++ b/pages/journal/create.tsx
@@ -1,0 +1,17 @@
+import { NextPage } from "next";
+import Head from "next/head";
+import Footer from "components/Footer";
+import Header from "components/Header";
+import CreateJournalEntry from "components/CreateJournalEntry";
+const Create: NextPage = () => {
+    return(
+        <main>
+            <Header/>
+            <CreateJournalEntry/>
+            <Footer/>
+        </main>
+    );
+
+}
+
+export default Create;

--- a/server/actions/Contentful.ts
+++ b/server/actions/Contentful.ts
@@ -1,21 +1,25 @@
 import {createClient} from "contentful-management";
 import fs from "fs";
 import {File} from "formidable";
-
+import {JournalEntry} from "utils/types";
 
 const client = createClient({
-    accessToken: process.env.CONTENTFUL_PERSONAL_TOKEN
+    accessToken: process.env.CONTENTFUL_PERSONAL_TOKEN as string
 });
 
 
-//https://www.contentful.com/developers/docs/references/content-management-api/#/reference/uploads/upload-a-file/creating-an-upload-resource/console/js
+/**
+* @param image Image file of type Formidable.File to be uploaded
+* @returns An object containing the uploaded image's asset ID and url. 
+* @throws  Error if resource creation is unsuccessful
+*/
 export async function uploadImage(image: File){
-    const space = await client.getSpace(process.env.CONTENTFUL_SPACE);
+    const space = await client.getSpace(process.env.CONTENTFUL_SPACE as string);
     const environment = await space.getEnvironment('master');
     let asset = await environment.createAssetFromFiles({
         fields: {
             title: {
-                'en-US': "Title",
+                'en-US': image.name,
             },
             description: {
                 "en-US": "Image description",
@@ -36,7 +40,6 @@ export async function uploadImage(image: File){
     if(asset == null){
        throw new Error("Asset creation unsuccessful.");
     } else {
-       
        //Delete image from local storage before ending upload
        fs.unlinkSync(image.path);
        //The url is returned without the http/https, so it's added here.
@@ -45,13 +48,74 @@ export async function uploadImage(image: File){
 
 }
 
-
+/**
+* @param ID ID of the Contentful Asset to be deleted
+* @returns True if deletion is successful, false if deletion failed.
+*/
 export async function deleteAssetByID(ID: string){
-    const space = await client.getSpace(process.env.CONTENTFUL_SPACE);
-    const environment = await  space.getEnvironment('master');
-    const asset = await environment.getAsset(ID); 
-    //Before an asset can be deleted, it has to be unpublished.
-    await asset.unpublish();
-    await asset.delete();
-    console.log("Asset deleted.");
+    try{
+        const space = await client.getSpace(process.env.CONTENTFUL_SPACE as string);
+        const environment = await  space.getEnvironment('master');
+        const asset = await environment.getAsset(ID); 
+        //Before an asset can be deleted, it has to be unpublished.
+        await asset.unpublish();
+        await asset.delete();
+        console.log("Asset deleted.");
+        return true;
+    } catch (error){
+        if(error) console.error(error);
+        return false;
+    }
 }
+
+/**
+* @param journalEntry Journal Entry information to be uploaded to Contentful
+* @returns True if creation is successful, false if creation is unsuccessful.
+*/
+export async function createJournalEntry(journalEntry: JournalEntry){
+    try{
+        const space = await client.getSpace(process.env.CONTENTFUL_SPACE as string);
+        const environment = await space.getEnvironment('master');
+        const entry = await environment.createEntry('blogPost', {
+            fields: {
+                title: {
+                    'en-US': journalEntry.title,
+                },
+                description: {
+                    'en-US': journalEntry.description,
+                },
+                category: {
+                    'en-US': journalEntry.category,
+                },
+                body: {
+                    'en-US': journalEntry.body,
+                },
+                reviewed: {
+                    'en-US': false,
+                },
+                image:{
+                    'en-US': {
+                        "sys": {
+                            type: "Link",
+                            linkType: "Asset",
+                            id: journalEntry.image?.assetID,
+                        }
+                    }
+                    
+                }
+            }
+        });
+        if(entry){
+            return true;
+        } 
+        return false;
+    } catch(error) {
+        if(error) console.error(error);
+        return false;
+    }
+}
+
+export async function getJournalEntriesByReviewStatus(status: boolean){
+    //TODO: Implement Contentful query to return all Entries based on status
+}
+

--- a/server/actions/Contentful.ts
+++ b/server/actions/Contentful.ts
@@ -115,7 +115,26 @@ export async function createJournalEntry(journalEntry: JournalEntry){
     }
 }
 
-export async function getJournalEntriesByReviewStatus(status: boolean){
-    //TODO: Implement Contentful query to return all Entries based on status
+/**
+* @param reviewed review status of the Journal Entries to be retrieved
+* @returns An array filled with Journal Entries retrieved or an empty object if there's an error.
+*/
+export async function getJournalEntriesByReviewStatus(reviewed: boolean){
+    try{
+        const space = await client.getSpace(process.env.CONTENTFUL_SPACE as string);
+        const environment = await space.getEnvironment('master');
+        const entries = await environment.getEntries({
+            content_type: 'blogPost',
+            fields: {
+                reviewed: reviewed,
+            },
+        });
+        return entries;
+    } catch (error) {
+        if(error) console.error(error);
+        return {};
+    }
 }
+
+
 

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -41,3 +41,11 @@ export interface Resource {
     category?: string;
     link?: string;
 }
+
+export interface JournalEntry{
+    title?: string,
+    description?: string,
+    image?: ContentfulImage,
+    category?: string,
+    body?: string,
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1311,6 +1311,13 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
+"@types/quill@1.3.10":
+  version "1.3.10"
+  resolved "https://registry.yarnpkg.com/@types/quill/-/quill-1.3.10.tgz#dc1f7b6587f7ee94bdf5291bc92289f6f0497613"
+  integrity sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==
+  dependencies:
+    parchment "^1.1.2"
+
 "@types/react-dom@^16.9.8":
   version "16.9.8"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.8.tgz#fe4c1e11dfc67155733dfa6aa65108b4971cb423"
@@ -2214,6 +2221,14 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+call-bind@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.0.tgz#24127054bb3f9bdcb4b1fb82418186072f77b8ce"
+  integrity sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==
+  dependencies:
+    function-bind "^1.1.1"
+    get-intrinsic "^1.0.0"
+
 caller-callsite@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/caller-callsite/-/caller-callsite-2.0.0.tgz#847e0fce0a223750a9a027c54b33731ad3154134"
@@ -2436,6 +2451,11 @@ clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
+
+clone@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
 
 coa@^2.0.2:
   version "2.0.2"
@@ -2705,6 +2725,14 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+create-react-class@^15.6.0:
+  version "15.7.0"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.7.0.tgz#7499d7ca2e69bb51d13faf59bd04f0c65a1d6c1e"
+  integrity sha512-QZv4sFWG9S5RUvkTYWbflxeZX+JG7Cz0Tn33rQBJ+WFQTqTfUTjMjiv9tnfXazjsO5r0KhPs+AqCjyrQX6h2ng==
+  dependencies:
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
 
 cross-fetch@3.0.4:
   version "3.0.4"
@@ -2989,6 +3017,18 @@ dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
+
+deep-equal@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
+  integrity sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==
+  dependencies:
+    is-arguments "^1.0.4"
+    is-date-object "^1.0.1"
+    is-regex "^1.0.4"
+    object-is "^1.0.1"
+    object-keys "^1.1.1"
+    regexp.prototype.flags "^1.2.0"
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -3534,6 +3574,11 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+eventemitter3@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-2.0.3.tgz#b5e1079b59fb5e1ba2771c0a993be060a58c99ba"
+  integrity sha1-teEHm1n7XhuidxwKmTvgYKWMmbo=
+
 events@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.1.0.tgz#84279af1b34cb75aa88bf5ff291f6d0bd9b31a59"
@@ -3597,6 +3642,11 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
+extend@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
 external-editor@^3.0.3:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
@@ -3624,6 +3674,11 @@ fast-deep-equal@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
   integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
+
+fast-diff@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.1.2.tgz#4b62c42b8e03de3f848460b639079920695d0154"
+  integrity sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==
 
 fast-diff@^1.1.2:
   version "1.2.0"
@@ -3874,6 +3929,15 @@ gauge@~2.7.3:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
+
+get-intrinsic@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.0.1.tgz#94a9768fcbdd0595a1c9273aacf4c89d075631be"
+  integrity sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
 
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.2"
@@ -4259,6 +4323,13 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-arguments@^1.0.4:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.0.tgz#62353031dfbee07ceb34656a6bde59efecae8dd9"
+  integrity sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==
+  dependencies:
+    call-bind "^1.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -4428,6 +4499,13 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
+
+is-regex@^1.0.4:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.1.tgz#c6f98aacc546f6cec5468a07b7b153ab564a57b9"
+  integrity sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==
+  dependencies:
+    has-symbols "^1.0.1"
 
 is-regex@^1.0.5:
   version "1.0.5"
@@ -4840,7 +4918,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.10, lodash@^4.17.19, lodash@^4.17.20:
+lodash@^4.17.10, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -4867,7 +4945,7 @@ log-update@^4.0.0:
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -5527,6 +5605,14 @@ object-inspect@^1.7.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.7.0.tgz#f4f6bd181ad77f006b5ece60bd0b6f398ff74a67"
   integrity sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==
 
+object-is@^1.0.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.4.tgz#63d6c83c00a43f4cbc9434eb9757c8a5b8565068"
+  integrity sha512-1ZvAZ4wlF7IyPVOcE1Omikt7UpaFlOQq0HlSti+ZvDH3UiD2brwGMwDbyV43jao2bKJ+4+WdPJHSd7kgzKYVqg==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+
 object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
@@ -5738,6 +5824,11 @@ parallel-transform@^1.1.0:
     cyclist "^1.0.1"
     inherits "^2.0.3"
     readable-stream "^2.1.5"
+
+parchment@^1.1.2, parchment@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/parchment/-/parchment-1.1.4.tgz#aeded7ab938fe921d4c34bc339ce1168bc2ffde5"
+  integrity sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg==
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -6319,7 +6410,7 @@ prop-types-extra@^1.1.0:
     react-is "^16.3.2"
     warning "^4.0.0"
 
-prop-types@15.7.2, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.7.2, prop-types@^15.5.10, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -6413,6 +6504,27 @@ querystring@0.2.0, querystring@^0.2.0:
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
+quill-delta@^3.6.2:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/quill-delta/-/quill-delta-3.6.3.tgz#b19fd2b89412301c60e1ff213d8d860eac0f1032"
+  integrity sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==
+  dependencies:
+    deep-equal "^1.0.1"
+    extend "^3.0.2"
+    fast-diff "1.1.2"
+
+quill@^1.3.7:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/quill/-/quill-1.3.7.tgz#da5b2f3a2c470e932340cdbf3668c9f21f9286e8"
+  integrity sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==
+  dependencies:
+    clone "^2.1.1"
+    deep-equal "^1.0.1"
+    eventemitter3 "^2.0.3"
+    extend "^3.0.2"
+    parchment "^1.1.4"
+    quill-delta "^3.6.2"
+
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -6462,6 +6574,11 @@ react-bootstrap@^1.3.0:
     uncontrollable "^7.0.0"
     warning "^4.0.3"
 
+react-dom-factories@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-dom-factories/-/react-dom-factories-1.0.2.tgz#eb7705c4db36fb501b3aa38ff759616aa0ff96e0"
+  integrity sha1-63cFxNs2+1AbOqOP91lhaqD/luA=
+
 react-dom@16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
@@ -6502,6 +6619,18 @@ react-overlays@^4.1.0:
     prop-types "^15.7.2"
     uncontrollable "^7.0.0"
     warning "^4.0.3"
+
+react-quill@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/react-quill/-/react-quill-1.3.5.tgz#8c4ad759da03365b17c79c6c52afa9772259844e"
+  integrity sha512-/W/rNCW+6QpGz8yQ9tFK5Ka/h/No1RqrcOOvCIOR092OiKzRFlU2xbPEwiP3Wgy/Dx13pi1YhjReDMX/5uotJg==
+  dependencies:
+    "@types/quill" "1.3.10"
+    create-react-class "^15.6.0"
+    lodash "^4.17.4"
+    prop-types "^15.5.10"
+    quill "^1.3.7"
+    react-dom-factories "^1.0.0"
 
 react-refresh@0.8.3:
   version "0.8.3"
@@ -6647,7 +6776,7 @@ regexp-clone@1.0.0, regexp-clone@^1.0.0:
   resolved "https://registry.yarnpkg.com/regexp-clone/-/regexp-clone-1.0.0.tgz#222db967623277056260b992626354a04ce9bf63"
   integrity sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw==
 
-regexp.prototype.flags@^1.3.0:
+regexp.prototype.flags@^1.2.0, regexp.prototype.flags@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz#7aba89b3c13a64509dabcf3ca8d9fbb9bdf5cb75"
   integrity sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==


### PR DESCRIPTION
This PR implements the frontend and the backend for Journal Entries. On the frontend, users are able to give an image, title, description, category, and then write out a body paragraph using Quill. 
![Screenshot_20201210_115604](https://user-images.githubusercontent.com/25257772/101810873-ea1f4280-3ade-11eb-87d7-0fec5aa671dd.png)
When a user uploads a file, the backround of the file select changes to the image uploaded.
![Screenshot_20201210_115550](https://user-images.githubusercontent.com/25257772/101810910-fb684f00-3ade-11eb-8193-9f3e30b94b3c.png)

When the publish button is clicked, a request to the API route `/api/journal/create` is sent. This route parses the form data, and uploads the data to Contentful. A new type, `JournalEntry`, has been added to make this process easier. 

I've also added in another backend function that allows us to retrieve entries by review status. This comes along with the API route `/api/journal/get`, which takes in a query from the url. By default, it will return the non-reviewed entries. You can also use `/api/journal/get?reviewed=false` to get non-reviewed entries. To get reviewed entries, you must make a request to `/api/journal/get?reviewed=true`. Please let me know if I need to make any changes.