### PR TITLE
Added National Board officers to main page (Quick-fix)

### DIFF
--- a/components/CreateJournalEntry/index.tsx
+++ b/components/CreateJournalEntry/index.tsx
@@ -28,7 +28,7 @@ const CreateJournalEntry: React.FC = () => {
         let target = e.target as HTMLInputElement;
         if(target != null){
             if(target.name == "image" && target.files != null){
-                setValues(values => ({...values, [target.name]: target.files[0]}));
+                setValues(values => ({...values, [target.name]: target.files?.item(0)}));
                 handleImageURL(target.files[0]);
             } else {
                 setValues(values => ({...values, [target.name]: target.value}));
@@ -49,7 +49,7 @@ const CreateJournalEntry: React.FC = () => {
         }
         
     }
-    const handleQuill = (content, delta, source, editor) => {
+    const handleQuill = (content: any, delta: any, source: any, editor: any) => {
         //If the editor is empty, the only thing in it is a newline character. We don't want to send just newlines to the backend, so we do this.
         if(editor.getText() != "\n"){
             if(values.body){

--- a/pages/api/blog/getBlog.ts
+++ b/pages/api/blog/getBlog.ts
@@ -1,0 +1,6 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    res.status(200).json({success: true})
+    res.end()
+}

--- a/pages/api/chapter/addChapter.ts
+++ b/pages/api/chapter/addChapter.ts
@@ -1,43 +1,58 @@
 import { NextApiResponse, NextApiRequest } from "next";
-import {uploadImage} from "server/actions/Contentful";
-import {addChapter} from "server/actions/Chapter"
+import { uploadImage } from "server/actions/Contentful";
+import { addChapter } from "server/actions/Chapter";
 import formidable from "formidable";
-import {Chapter} from "utils/types";
+import { Chapter } from "utils/types";
 //To get formidable to work, bodyParser has to be turned off. Otherwise, the parse request will never end.
 export const config = {
-  api: {
-    bodyParser: false,
-  },
+    api: {
+        bodyParser: false,
+    },
 };
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse){
+export default async function handler(
+    req: NextApiRequest,
+    res: NextApiResponse
+) {
     const form = new formidable.IncomingForm();
-    form.parse(req, async (err:any, fields: formidable.Fields ,files: formidable.Files) => { 
-        //Fields is used for everything other than files, so all this data can be passed in directly to the chapter type.
-        let chapterInfo: Chapter = fields;
-        
-        
-        //Since we use names in the url, names need to be parsed and have all whitespace converted to underscores
-        chapterInfo.name = chapterInfo.name.replace(/ /g, "_");
+    form.parse(
+        req,
+        async (
+            err: any,
+            fields: formidable.Fields,
+            files: formidable.Files
+        ) => {
+            //Fields is used for everything other than files, so all this data can be passed in directly to the chapter type.
+            const chapterInfo: Chapter = fields;
 
-        //Since these two don't rely on each other to be uploaded, doing this allows them to be done simultaneously, and should be more efficient
-        [chapterInfo.campusPic, chapterInfo.universityLogo] = await Promise.all([uploadImage(files.campus), uploadImage(files.logo)]);
+            //Since we use names in the url, names need to be parsed and have all whitespace converted to underscores
+            if (chapterInfo.name)
+                chapterInfo.name = chapterInfo.name.replace(/ /g, "_");
 
-        //Now that all data is prepped, we can add chapter.
-        await addChapter(chapterInfo)
-        .then((payload) => {
-            res.status(200).json({
-                success: true,
-                payload,
-            })
-        })
-        .catch((error) => {
-            console.error(error);
-            res.status(400).json({
-                success: false,
-                message: error,
-            })
-        });
-    });
+            //Since these two don't rely on each other to be uploaded, doing this allows them to be done simultaneously, and should be more efficient
+            [
+                chapterInfo.campusPic,
+                chapterInfo.universityLogo,
+            ] = await Promise.all([
+                uploadImage(files.campus),
+                uploadImage(files.logo),
+            ]);
+
+            //Now that all data is prepped, we can add chapter.
+            await addChapter(chapterInfo)
+                .then(payload => {
+                    res.status(200).json({
+                        success: true,
+                        payload,
+                    });
+                })
+                .catch(error => {
+                    console.error(error);
+                    res.status(400).json({
+                        success: false,
+                        message: error as Error,
+                    });
+                });
+        }
+    );
 }
-

--- a/pages/chapters/[name].tsx
+++ b/pages/chapters/[name].tsx
@@ -2,7 +2,7 @@ import Header from "components/Header";
 import Footer from "components/Footer";
 import OfficerCarouselComp from "components/OfficerCarousel";
 import { getChapters } from "server/actions/Chapter";
-import { getOfficers } from "requests/Officer";
+import { getOfficers } from "server/actions/Officer";
 import { Chapter, Officer } from 'utils/types';
 import { GetStaticPropsContext, NextPage, NextPageContext } from 'next';
 import { FaMapMarkerAlt } from "react-icons/fa";

--- a/pages/chapters/[name].tsx
+++ b/pages/chapters/[name].tsx
@@ -1,10 +1,10 @@
 import Header from "components/Header";
 import Footer from "components/Footer";
 import OfficerCarouselComp from "components/OfficerCarousel";
-import { getChapters } from "requests/Chapter";
+import { getChapters } from "server/actions/Chapter";
 import { getOfficers } from "requests/Officer";
 import { Chapter, Officer } from 'utils/types';
-import { NextPage, NextPageContext } from 'next';
+import { GetStaticPropsContext, NextPage, NextPageContext } from 'next';
 import { FaMapMarkerAlt } from "react-icons/fa";
 import errors from 'utils/errors';
 import Head from "next/head";
@@ -61,10 +61,12 @@ const ChapterPage: NextPage<Props> = ({ chapter, officers }) => {
             {chapter.description}
           </p>
         </div>
+        { officers.length > 0 &&
         <div className="chapterOfficerParent bodySection">
           <h2>Meet the Team</h2>
           <OfficerCarouselComp officers={officers} />
         </div>
+        }
       </div>
       
       <Footer />
@@ -191,10 +193,10 @@ const ChapterPage: NextPage<Props> = ({ chapter, officers }) => {
 
 // This function cant be in child component, so we query the data and 
 // then pass it to the component. It's ran server-side
-ChapterPage.getInitialProps = async ( context: NextPageContext ) => {
+export async function getStaticProps(context: GetStaticPropsContext) {
   // query by the chapter's name
   let chapterQuery: Chapter = new Object;
-  chapterQuery.name = context.query.name as string;
+  chapterQuery.name = context.params?.name as string;
 
   var chapter: Chapter = new Object;
   var chapters: Chapter[] = await getChapters(chapterQuery);
@@ -213,13 +215,25 @@ ChapterPage.getInitialProps = async ( context: NextPageContext ) => {
   if (!(officers.length > 0))
   {
     // TODO route to an error page
-    throw new Error(errors.GENERIC_ERROR);
+    //throw new Error(errors.GENERIC_ERROR);
   }
 
   return {
-      chapter: chapter,
-      officers: officers
+    props: {
+      chapter: JSON.parse(JSON.stringify(chapter)),
+      officers: JSON.parse(JSON.stringify(officers)),
+    },
   }
+}
+
+export async function getStaticPaths() {
+  let chapters: Chapter[] = await getChapters({});
+
+  let paths = chapters.map((chapter) => ({
+    params: {name: chapter.name},
+  }));
+
+  return { paths, fallback: false}
 }
 
 export default ChapterPage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,19 @@
-import { NextPage } from "next";
+import { NextPage, NextPageContext } from "next";
 import Head from "next/head";
 import Footer from "components/Footer";
 import Header from "components/Header";
 import MainInfo from "components/MainInfo";
 import Partners from "components/Partners";
 import HomeChapters from "components/HomeChapters";
-const Home: NextPage = () => {
+import OfficerCarouselComp from "components/OfficerCarousel"
+import { Officer } from "utils/types";
+import { getOfficers } from "server/actions/Officer";
+
+interface Props {
+  officers: Officer[]
+}
+
+const Home: NextPage<Props> = ({officers}) => {
   return (
     <div className="container">
       <Head>
@@ -16,6 +24,14 @@ const Home: NextPage = () => {
       <Header />
       <MainInfo />
       <Partners />
+      {
+      <div className="bodyContent">
+        <div className="chapterOfficerParent bodySection">
+           <h2>Meet the National Board</h2>
+           <OfficerCarouselComp officers={officers} />
+       </div>
+      </div>
+    }
       <HomeChapters />
       <Footer />
 
@@ -27,6 +43,31 @@ const Home: NextPage = () => {
           justify-content: center;
           align-items: center;
         }
+
+        .chapterOfficerParent h2{
+          position: relative;
+          display: block;
+          text-align: left;
+          font-size: 38px;
+          color: black;
+        }
+        
+        .bodySection{
+          width: auto;
+          height: auto;
+          position: relative;
+          display: block;
+          padding: 20px 0px;
+        }
+
+        .bodyContent{
+          width: auto;
+          height: auto;
+          position: relative;
+          display: block;
+          padding: 60px;
+        }
+
       `}</style>
 
       <style jsx global>{`
@@ -46,5 +87,16 @@ const Home: NextPage = () => {
     </div>
   );
 };
+
+export async function getStaticProps(context:NextPageContext) {
+  let offficerQuery: Officer = {chapter: 'national'}
+  let officers: Officer[] = await getOfficers(offficerQuery)
+
+  return {
+    props: {
+      officers: JSON.parse(JSON.stringify(officers))
+    }
+  }
+}
 
 export default Home;

--- a/pages/officer/[name].tsx
+++ b/pages/officer/[name].tsx
@@ -15,7 +15,7 @@ const OfficerPage: NextPage<Props> = ({ officers }) => {
       <p> hello from the main page </p>
       <>
         {officers.map(officer => (
-          <OfficerComp key={officer._id} officer={officer}/>
+          <OfficerComp key={officer._id as unknown as string} officer={officer}/>
         ))}
       </>
       <Footer />

--- a/pages/officer/addOfficer.tsx
+++ b/pages/officer/addOfficer.tsx
@@ -2,7 +2,7 @@ import { NextPage } from "next";
 import { addOfficer } from "requests/Officer";
 import { Officer } from "utils/types"
 
-const handleSubmit = async (e) => {
+const handleSubmit = async (e: any) => {
     e.preventDefault();
     const formData = new FormData(e.target);
     var officer: Officer = await addOfficer(formData);

--- a/pages/officer/updateOfficer.tsx
+++ b/pages/officer/updateOfficer.tsx
@@ -1,0 +1,11 @@
+import { NextPage } from "next";
+
+const updateOfficerPage: NextPage = () => {
+    return (
+        <div>
+
+        </div>
+    )
+}
+
+export default updateOfficerPage;

--- a/pages/portal/chapters/[name].tsx
+++ b/pages/portal/chapters/[name].tsx
@@ -1,0 +1,11 @@
+import { NextPage } from "next";
+
+const nameChapterPage: NextPage = () => {
+    return(
+        <div>
+
+        </div>
+    )
+}
+
+export default nameChapterPage;

--- a/server/actions/Officer.ts
+++ b/server/actions/Officer.ts
@@ -12,15 +12,18 @@ export const getOfficers = async function (officerInfo: Officer) {
 
     if(!officerInfo) officerInfo = {}
 
-    return await OfficerSchema.find(officerInfo)
-    .exec()
-    .then(async (officers) => {
-        // todo maybe handle this error on front end
-        if(officers == null)
-            throw new Error("Officers do not exist")
+    let officers = await OfficerSchema.find(officerInfo)
+    
+    if(officers == null) throw new Error("Officers do not exist")
+
+    return officers
+    // .then(async (officers) => {
+    //     // todo maybe handle this error on front end
+    //     if(officers == null)
+            
         
-        return officers;
-    })
+    //     return officers;
+    // })
 }
 
 

--- a/utils/urls.ts
+++ b/utils/urls.ts
@@ -23,5 +23,8 @@ export default {
             get: "/api/chapter/getChapter",
             update: "/api/chapter/updateChapter",
         },
+        officer: {
+            get: "/api/officer/getOfficers",
+        }
     },
 };


### PR DESCRIPTION
Main Changes
---
- I added the national board members of MindVersity on the home page using an OfficerCarousel (from @jovanyoshioka).
- I modified the individual chapter page to now utilize `getStaticProps` and `getStaticPaths` to statically build all of the individual chapters' pages
    - used functions from server folder directly in `getStaticProps` to allow for the optimized build to run without having the API service running
- Some other minor changes throughout the project that fixed errors when using `yarn build` (`next build`)
    - Made sure variables are marked with `any` rather than typescript implicitly defining as any
    - Added some code to empty files to ensure they are treated as modules

*Please let me know if anything doesn't look right*