### PR TITLE
Admin Portal Review Journals 

### DIFF
--- a/components/Portal/JournalEntry/index.tsx
+++ b/components/Portal/JournalEntry/index.tsx
@@ -1,25 +1,39 @@
 import styles from "./journalentry.module.scss";
-import {EntryProp} from "contentful-management/dist/typings/entities/entry";
+import {JournalEntry} from "utils/types";
+import {useState} from "react";
 interface Props{
-    entry: EntryProp;
+    entry: JournalEntry;
     mode: string; //Because Delete Journal and Update Journal require a similar component, this prop allows us to swap out things needed in each inside this component. This keeps us from having to make two components that are basically the same thing. There's two modes: delete and review.
 }
-const JournalEntry: React.FC<Props> = ({entry, mode}) => {
+const JournalEntryComponent: React.FC<Props> = ({entry, mode}) => {
+    const handleEntryApproval = (e:React.SyntheticEvent) => {
+        e.preventDefault();
+        let submitButton = e.target as HTMLButtonElement;
+        if(submitButton.name === "approve"){
+            //Approve the entry...
+        }
+        if(submitButton.name === "reject"){
+            //Reject it and display some kind of modal that explains to the user that they are deleting the post. 
+        }
+    };
     return(
         <form className={styles['entry']}>
             <div className={styles['entryBody']}>
-                <h1 className={styles['title']}>{entry.fields.title['en-US']}</h1>
-                <p className={styles['description']}>{entry.fields.description['en-US']}</p>
+                <h1 className={styles['title']}>{entry.title}</h1>
+                <p className={styles['description']}>{entry.description}</p>
             </div>
             <div className={styles['actionButtonContainer']}>
                 { mode === "delete" && (
                     <button className={styles['actionButton']}>Delete</button>
                 ) }
                 { mode === "review" && (
-                    <button className={styles['actionButton']}>Review</button>
+                    <div>
+                        <button name="approve" type="submit" className={`${styles['actionButtonPrimary']} ${styles['actionButton']}`} onClick={handleEntryApproval} value={entry.id}>Approve</button>
+                        <button name="reject" type="submit" className={`${styles['actionButtonSecondary']} ${styles['actionButton']}`} onClick={handleEntryApproval} value={entry.id}>Reject</button>
+                    </div>
                 ) }
             </div>
         </form>
     )
 };
-export default JournalEntry;
+export default JournalEntryComponent;

--- a/components/Portal/JournalEntry/index.tsx
+++ b/components/Portal/JournalEntry/index.tsx
@@ -1,23 +1,13 @@
 import styles from "./journalentry.module.scss";
 import {JournalEntry} from "utils/types";
-import {useState} from "react";
 interface Props{
     entry: JournalEntry;
     mode: string; //Because Delete Journal and Update Journal require a similar component, this prop allows us to swap out things needed in each inside this component. This keeps us from having to make two components that are basically the same thing. There's two modes: delete and review.
+    handleEntryApproval: any;
 }
-const JournalEntryComponent: React.FC<Props> = ({entry, mode}) => {
-    const handleEntryApproval = (e:React.SyntheticEvent) => {
-        e.preventDefault();
-        let submitButton = e.target as HTMLButtonElement;
-        if(submitButton.name === "approve"){
-            //Approve the entry...
-        }
-        if(submitButton.name === "reject"){
-            //Reject it and display some kind of modal that explains to the user that they are deleting the post. 
-        }
-    };
+const JournalEntryComponent: React.FC<Props> = ({entry, mode, handleEntryApproval}) => {
     return(
-        <form className={styles['entry']}>
+        <div className={styles['entry']}>
             <div className={styles['entryBody']}>
                 <h1 className={styles['title']}>{entry.title}</h1>
                 <p className={styles['description']}>{entry.description}</p>
@@ -28,12 +18,12 @@ const JournalEntryComponent: React.FC<Props> = ({entry, mode}) => {
                 ) }
                 { mode === "review" && (
                     <div>
-                        <button name="approve" type="submit" className={`${styles['actionButtonPrimary']} ${styles['actionButton']}`} onClick={handleEntryApproval} value={entry.id}>Approve</button>
-                        <button name="reject" type="submit" className={`${styles['actionButtonSecondary']} ${styles['actionButton']}`} onClick={handleEntryApproval} value={entry.id}>Reject</button>
+                        <button name="approve" type="submit" className={`${styles['actionButtonPrimary']} ${styles['actionButton']}`} onClick={(e:React.SyntheticEvent) => handleEntryApproval(e)} value={entry.id}>Approve</button>
+                        <button name="rejecting" type="submit" className={`${styles['actionButtonSecondary']} ${styles['actionButton']}`} onClick={(e:React.SyntheticEvent) => handleEntryApproval(e)} value={entry.id}>Reject</button>
                     </div>
                 ) }
             </div>
-        </form>
+        </div>
     )
 };
 export default JournalEntryComponent;

--- a/components/Portal/JournalEntry/journalentry.module.scss
+++ b/components/Portal/JournalEntry/journalentry.module.scss
@@ -35,17 +35,36 @@ $color: #8C69AA;
     width: 230px;
     height: 50px;
     border-radius: 6px;
-    background: $color;
-    color: white;
     font-size: 1.2rem;
-    border:none;
+    border: 1px solid $color;
     cursor:pointer;
     transition:0.5s ease;
     align-self: flex-end;
-
-    &:hover{
-        filter:brightness(1.2);
+    margin: 10px;
+    &.actionButtonPrimary {
+        background: $color;
+        color: white;
+        &:hover{
+            filter:brightness(1.2);
+        }
     }
+    &.actionButtonSecondary{
+        background: white;
+        color: $color;
+        &:hover{
+            filter:brightness(0.8);
+        }
+    }
+    &:hover{
+        transform: translateY(-2px);
+    }
+}
+
+.rejectingModal{
+    position:absolute;
+    width:100%;
+    height:100%;
+    text-align:center;
 }
 
 @media only screen and (max-width:999px){
@@ -66,3 +85,4 @@ $color: #8C69AA;
         margin-bottom:10px;
     }
 }
+

--- a/pages/api/journal/review.ts
+++ b/pages/api/journal/review.ts
@@ -1,0 +1,26 @@
+import {NextApiRequest, NextApiResponse} from "next";
+import {updateJournalEntryReviewStatus, deleteJournalEntryById} from "server/actions/Contentful";
+
+export default async function handler(req:NextApiRequest, res:NextApiResponse){
+    let success;
+    if(req.query.approved === "true"){
+         success =  await updateJournalEntryReviewStatus(req.query.id as string);
+         //If update was successful, return a message to the client saying so.
+         if(success){
+             res.status(200).json({message: "Entry successfully approved."});
+         } else {
+             res.status(400).json({message:"Something went wrong. Please try again."});
+         }
+    }
+
+    if(req.query.approved === "false"){
+        success = await deleteJournalEntryById(req.query.id as string);
+        //If entry was successfully deleted, return a message to the client.
+        if(success){
+            res.status(200).json({message: "Entry successfully rejected."});
+        } else {
+            res.status(400).json({message: "Something went wrong, please try again."});
+        }
+    }
+
+}

--- a/pages/portal/journal/delete.tsx
+++ b/pages/portal/journal/delete.tsx
@@ -2,10 +2,10 @@ import { NextPage,  NextPageContext } from "next";
 import Head from "next/head";
 import Navigation from "components/Portal/Navigation";
 import urls from "utils/urls";
-import JournalEntry from "components/Portal/JournalEntry";
-import {EntryProp} from "contentful-management/dist/typings/entities/entry";
+import JournalEntryComponent from "components/Portal/JournalEntry";
+import {JournalEntry} from "utils/types";
 interface Props{
-    entries: EntryProp[],
+    entries: JournalEntry[],
 }
 
 const AdminJournalDelete: NextPage<Props> = ({entries}) => {
@@ -20,7 +20,7 @@ const AdminJournalDelete: NextPage<Props> = ({entries}) => {
                 {entries && (
                     entries.map(entry => {
                         return (
-                            <JournalEntry key={entry.sys.id} entry={entry} mode="delete"/>
+                            <JournalEntryComponent key={entry.id} entry={entry} mode="delete"/>
                         )
                     })
                 )}
@@ -69,8 +69,7 @@ AdminJournalDelete.getInitialProps = async (context: NextPageContext) => {
     const response = await fetch(url, {
         method: "GET",
     });
-    let data = await response.json();
-    let entries: Array<EntryProp> = data.items;
+    let entries = await response.json();
     
     return{
         entries,

--- a/pages/portal/journal/review.tsx
+++ b/pages/portal/journal/review.tsx
@@ -20,7 +20,7 @@ const AdminJournalReview: NextPage<Props> = ({entries}) => {
                 {entries && (
                     entries.map(entry => {
                         return (
-                            <JournalEntry key={entry.sys.id} entry={entry} mode="review"/>
+                            <JournalEntry key={entry.id} entry={entry} mode="review"/>
                         )
                     })
                 )}
@@ -69,9 +69,7 @@ AdminJournalReview.getInitialProps = async (context: NextPageContext) => {
     const response = await fetch(url, {
         method: "GET",
     });
-    let data = await response.json();
-    let entries: Array<EntryProp> = data.items;
-    
+    let entries = await response.json();
     return{
         entries,
     }

--- a/pages/portal/journal/review.tsx
+++ b/pages/portal/journal/review.tsx
@@ -81,11 +81,14 @@ const AdminJournalReview: NextPage<Props> = ({entries}) => {
                     </div>
                 </div>
             )}
+
+
             <Navigation />
+
             <form className="content"> 
                 {responseStatus === 200 && (
                     <div className="success">
-                        <p>Entry successfully approved!</p>
+                        <p>Entry action successful.</p>
                     </div>
                 )}
                 {responseStatus === 400 && (
@@ -220,11 +223,11 @@ const AdminJournalReview: NextPage<Props> = ({entries}) => {
 }
 AdminJournalReview.getInitialProps = async (context: NextPageContext) => {
     //Load the journal entries that haven't been reviewed.
-    const url:string = `${urls.baseUrl}/api/journal/getByReviewStatus?reviewed=false`;
+    const url:string = `${urls.baseUrl as string}/api/journal/getByReviewStatus?reviewed=false`;
     const response = await fetch(url, {
         method: "GET",
     });
-    let entries = await response.json();
+    let entries: JournalEntry[] = await response.json();
     return{
         entries,
     }

--- a/pages/portal/journal/review.tsx
+++ b/pages/portal/journal/review.tsx
@@ -2,31 +2,157 @@ import { NextPage,  NextPageContext } from "next";
 import Head from "next/head";
 import Navigation from "components/Portal/Navigation";
 import urls from "utils/urls";
-import JournalEntry from "components/Portal/JournalEntry";
-import {EntryProp} from "contentful-management/dist/typings/entities/entry";
+import JournalEntryComponent from "components/Portal/JournalEntry";
+import {JournalEntry} from "utils/types";
+import {useState} from "react";
 interface Props{
-    entries: EntryProp[],
+    entries: JournalEntry[],
 }
 
 const AdminJournalReview: NextPage<Props> = ({entries}) => {
+    const [isRejecting, setIsRejecting] = useState(false); //Displays the warning modal
+    const [warningDismissed, setWarningDismissed] = useState(false); //Used inside the warning modal to determine whether or not it should pop up again.
+    const [currentRejectingID, setRejectingID] = useState(""); //The entry IDs are stored on the buttons of each entry, and since the modal is not attached to any particular entry, it has no way of getting an entry's ID. To get the entry ID, when the Reject button is initially clicked, the ID of that particular entry is stored here so it can be used within the modal.
+    const [responseStatus, setResponseStatus] = useState(0); //Used to display a success/error message.
+    
+
+
+    const handleEntryApproval = async (e:React.SyntheticEvent) => {
+        e.preventDefault();
+        let response;
+        let submitButton = e.target as HTMLButtonElement;
+        if(submitButton.name === "approve"){
+            //Approve the entry...
+            response = await fetch(`/api/journal/review?approved=true&id=${submitButton.value}`, {
+                method: "PUT",
+            });
+            setResponseStatus(response.status);
+
+        }
+
+        //Button by the approve button
+        if(submitButton.name === "rejecting"){
+            //If the user has viewed the warning modal and selects the option to not view it again, then the next time they click the reject button, the entry will be rejected.
+            if(!isRejecting && warningDismissed){
+                response = await fetch(`/api/journal/review?approved=false&id=${submitButton.value}`, {
+                    method: "PUT",
+                });
+                setResponseStatus(response.status);
+
+            } else {
+                setIsRejecting(true);
+                setRejectingID(submitButton.value);
+            }
+        }
+
+        //This button is within the reject modal. If a user chooses to not dismiss the warning, then they can click the reject button within it to reject the entry.
+        if(submitButton.name === "reject"){
+            //Reject here...
+            setIsRejecting(false);
+            response = await fetch(`/api/journal/review?approved=false&id=${currentRejectingID}`, {
+                method: "PUT",
+            });
+            setResponseStatus(response.status);
+        } 
+    };
+
+    const toggleWarningDismissed = (e:React.SyntheticEvent) => {
+        setWarningDismissed(true);
+    }
+
+
+
     return(
         <main className="wrapper">
             <Head>
                 <title>Review Journal Entries | Mindversity Website</title>
             </Head>
+            {isRejecting && (
+                <div className="rejectModal">
+                    <div className="modalBody">
+                        <h1>Are you sure?</h1>
+                        <p>Continuing with this action will delete the entry permanently.</p>
+                        <input type='checkbox' onClick={toggleWarningDismissed}/>
+                        <span>Do not show this message again.</span>
+                        <div className="actionButtonContainer">
+                            <button type="submit" name="reject" className="actionButton actionButtonPrimary" onClick={handleEntryApproval}>Reject</button>
+                            <button className="actionButton actionButtonSecondary" onClick={() => {setIsRejecting(false); setRejectingID("")}}>Close</button>
+                        </div>
+                    </div>
+                </div>
+            )}
             <Navigation />
-            <div className="content">
-                <h1>Posts to be reviewed</h1>
+            <form className="content"> 
+                {responseStatus === 200 && (
+                    <div className="success">
+                        <p>Entry successfully approved!</p>
+                    </div>
+                )}
+                {responseStatus === 400 && (
+                    <div className="error">
+                        <p>Something went wrong. Please try again</p>
+                    </div>
+                )}
+
+
+                <h1 className="contentHeader">Posts to be reviewed</h1>
                 {entries && (
                     entries.map(entry => {
                         return (
-                            <JournalEntry key={entry.id} entry={entry} mode="review"/>
+                            <JournalEntryComponent key={entry.id} entry={entry} handleEntryApproval={handleEntryApproval} mode="review"/>
                         )
                     })
                 )}
 
-            </div>
+            </form>
             <style jsx>{`
+                .actionButton{
+                    width: 230px;
+                    height: 50px;
+                    border-radius: 6px;
+                    font-size: 1.2rem;
+                    border: 1px solid #8C69AA;
+                    cursor:pointer;
+                    transition:0.5s ease;
+                    align-self: flex-end;
+                    margin: 10px;
+                }
+                .actionButtonPrimary {
+                    background: #8C69AA;
+                    color: white;
+                }
+                .actionButtonPrimary:hover{
+                    filter:brightness(1.2);
+                }
+                .actionButtonSecondary{
+                    background: white;
+                    color: #8C69AA;
+                }
+                .actionButtonSecondary:hover{
+                    filter:brightness(0.8);
+                }
+                .modalBody{
+                    background: white;
+                    width:500px;
+                    height:300px;
+                    padding:0.5rem;
+                    text-align:center;
+                    align-self:center;
+                }
+                .success{
+                    background: #a8ff9e;
+                    margin: 10px;
+                    border: 1px solid #095400;
+                    color: #095400;
+                    text-align:center;
+                }
+                .error{
+                    background: #ff8a82;
+                    margin: 10px;
+                    color: #590601;
+                    border: 1px solid #940900;
+                    text-align:center;
+                }
                 @media screen and (min-width: 1000px){
                     .content {
                         margin-left: 430px;
@@ -34,16 +160,45 @@ const AdminJournalReview: NextPage<Props> = ({entries}) => {
                         display:flex;
                         flex-direction:column;
                         height: 100vh;
+                        position:relative;
+                    }
+                    .rejectModal{
+                        width:100%;
+                        position:absolute;
+                        display:flex;
+                        flex-direction:column;
+                        justify-content:center;
+                        align-items:center;
+                        height:100%;
+                        background:rgba(0,0,0,0.2);
+                        z-index:2;
+                    }
+                    .modalBody{
+                        margin-left:430px;
+                        margin-right: 60px;
                     }
                 }
                 @media screen and (max-width: 999px){
                     .content {
-                        margin-top:30px;
                         margin-left: 30px;
                         margin-right:30px;
                         display:flex;
                         flex-direction:column;
                         height: 100vh;
+                    }
+                    .rejectModal{
+                        width:100%;
+                        position:absolute;
+                        display:flex;
+                        flex-direction:column;
+                        justify-content:center;
+                        align-items:center;
+                        height:100%;
+                        background:rgba(0,0,0,0.2);
+                        z-index:2;
+                    }
+                    .contentHeader{
+                        text-align:center;
                     }
                 }
             `}</style>

--- a/server/actions/Contentful.ts
+++ b/server/actions/Contentful.ts
@@ -128,6 +128,7 @@ export async function getJournalEntriesByReviewStatus(reviewed: boolean){
             journalEntry.id = entries.items[i].sys.id; // unique id for the asset
             journalEntry.body = entries.items[i].fields.body['en-US'];
             journalEntry.category = entries.items[i].fields.category['en-US'];
+            journalEntry.reviewed=  entries.items[i].fields.reviewed['en-US'];
             journalEntry.description = entries.items[i].fields.description['en-US'];
             journalEntry.image = entries.items[i].fields.image['en-US'];
             journalEntry.title = entries.items[i].fields.title['en-US'];
@@ -167,6 +168,7 @@ export async function getJournalEntryById(id: string){
         journalEntry.id = entries.items[0].sys.id; // unique id for the asset
         journalEntry.body = entries.items[0].fields.body['en-US'];
         journalEntry.category = entries.items[0].fields.category['en-US'];
+        journalEntry.reviewed=  entries.items[0].fields.reviewed['en-US'];
         journalEntry.description = entries.items[0].fields.description['en-US'];
         journalEntry.image = entries.items[0].fields.image['en-US'];
         journalEntry.title = entries.items[0].fields.title['en-US'];
@@ -208,3 +210,24 @@ export async function getJournalEntryByType(type: string){
         return {};
     }
 }
+
+/**
+* @param id ID of the JournalEntry to be updated
+* @returns Updated entry if successful. Empty object if unsuccessful.
+*/
+export async function updateJournalEntryReviewStatus(id: string){
+    try{
+        const space = await client.getSpace(process.env.CONTENTFUL_SPACE as string);
+        const environment = await space.getEnvironment(process.env.CONTENTFUL_ENVIRONMENT as string);
+        const entry = await environment.getEntry(id);
+        //Review status would only ever go from false to true, so there's no need to specify what the status would be.
+        entry.fields.reviewed['en-US'] = true;
+        return entry.update();
+
+    } catch (error){
+        if(error) console.error(error);
+        return {};
+    }
+}
+
+

--- a/server/actions/Contentful.ts
+++ b/server/actions/Contentful.ts
@@ -167,7 +167,7 @@ export async function getJournalEntryById(id: string){
         journalEntry.id = entries.items[0].sys.id; // unique id for the asset
         journalEntry.body = entries.items[0].fields.body['en-US'];
         journalEntry.category = entries.items[0].fields.category['en-US'];
-        journalEntry.reviewed=  entries.items[0].fields.reviewed['en-US'];
+        journalEntry.reviewed =  entries.items[0].fields.reviewed['en-US'];
         journalEntry.description = entries.items[0].fields.description['en-US'];
         journalEntry.image = entries.items[0].fields.image['en-US'];
         journalEntry.title = entries.items[0].fields.title['en-US'];

--- a/server/actions/Contentful.ts
+++ b/server/actions/Contentful.ts
@@ -127,7 +127,7 @@ export async function getJournalEntriesByReviewStatus(reviewed: boolean){
             journalEntry.id = entries.items[i].sys.id; // unique id for the asset
             journalEntry.body = entries.items[i].fields.body['en-US'];
             journalEntry.category = entries.items[i].fields.category['en-US'];
-            journalEntry.reviewed=  entries.items[i].fields.reviewed['en-US'];
+            journalEntry.reviewed =  entries.items[i].fields.reviewed['en-US'];
             journalEntry.description = entries.items[i].fields.description['en-US'];
             journalEntry.image = entries.items[i].fields.image['en-US'];
             journalEntry.title = entries.items[i].fields.title['en-US'];

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -50,4 +50,5 @@ export interface JournalEntry {
     category?: string,
     body?: string,
     dateCreated?: string,
+    reviewed?: boolean,
 }


### PR DESCRIPTION
In this PR, I integrated the backend to the frontend of the admin portal's review journal page. The frontend is somewhat complex,  but I'll do my best to explain what exactly is going on. To start, I've made some changes to the `
JournalEntry` component that is present on this page. Instead of having one button that says "Review," it has been split into two buttons, "Approve" and "Reject."
![overview](https://user-images.githubusercontent.com/25257772/102401258-a463ed80-3fa8-11eb-84bb-907f914a90f4.png)

On these buttons, the ID of the journal entry is stored. When the "Approve" button is pressed, the ID is  taken from the button, and a request is sent to the backend to update the entry's review status. If the "Reject" button is selected, a modal appears that warns the user that their actions will delete the entry. 
![modal](https://user-images.githubusercontent.com/25257772/102401497-0a507500-3fa9-11eb-8b7d-1f136d007a2e.png)

This modal is not attached  to the `JournalEntry` component, and because of that, it has no way to get the entry ID from the "Reject" button. The best way I could come up with is to store the entry ID of the last pressed "Reject" button in a state. If the modal is closed, then the ID is cleared. There's probably a better way to do this, but we can look into this later. Within the modal, the user has the option to reject the entry they have selected, or to close the modal. If they select the checkbox, then the modal will no longer appear upon pressing the reject button, and instead a request will immediately be sent to the backend to delete the entry.

Regardless of the action done, there are two messages that can appear after the request to the backend has been made. If the action was successful, then this message will show:
![success](https://user-images.githubusercontent.com/25257772/102402000-c0b45a00-3fa9-11eb-88c5-59b8c5995cbc.png)
If there was some sort of error, then this message will show:
![error](https://user-images.githubusercontent.com/25257772/102402019-cdd14900-3fa9-11eb-8b42-e0d06551975b.png)

The only things missing from the page at this point are a link to view the entire article, and a way to refresh the list after the action has occured. I will add in the links once Zavier has finished the frontend for viewing individual blog posts. Please let me know if I need to change anything.