### PR TITLE
Delete journal backend integration

### DIFF
--- a/components/Portal/JournalEntry/index.tsx
+++ b/components/Portal/JournalEntry/index.tsx
@@ -14,8 +14,7 @@ const JournalEntryComponent: React.FC<Props> = ({entry, mode, handleEntryApprova
             </div>
             <div className={styles['actionButtonContainer']}>
                 { mode === "delete" && (
-                    <button className={styles['actionButton']}>Delete</button>
-                ) }
+                     <button name="deleting" className={`${styles['actionButton']} ${styles['actionButtonPrimary']}`} onClick={(e) => handleEntryApproval(e)} value={entry.id}>Delete</button>) }
                 { mode === "review" && (
                     <div>
                         <button name="approve" type="submit" className={`${styles['actionButtonPrimary']} ${styles['actionButton']}`} onClick={(e:React.SyntheticEvent) => handleEntryApproval(e)} value={entry.id}>Approve</button>

--- a/pages/portal/journal/delete.tsx
+++ b/pages/portal/journal/delete.tsx
@@ -4,29 +4,146 @@ import Navigation from "components/Portal/Navigation";
 import urls from "utils/urls";
 import JournalEntryComponent from "components/Portal/JournalEntry";
 import {JournalEntry} from "utils/types";
+import {useState} from "react";
+
 interface Props{
     entries: JournalEntry[],
 }
 
 const AdminJournalDelete: NextPage<Props> = ({entries}) => {
+
+    const [isDeleting, setIsDeleting] = useState(false);
+    const [responseStatus, setResponseStatus] = useState(0);
+    const [warningDismissed, setWarningDismissed] = useState(false);
+    const [deletingID, setDeletingID] = useState("");
+    const handleEntryApproval = async (e:React.SyntheticEvent) => {
+        e.preventDefault();
+        let response;
+        const submitButton = e.target as HTMLButtonElement;
+
+
+        if(submitButton.name === "deleting"){
+            if(!isDeleting && warningDismissed){
+                response = await fetch(`/api/journal/deleteByID?id=${submitButton.value}`, {
+                    method: "DELETE",
+                });
+                setResponseStatus(response.status);
+            } else {
+                setIsDeleting(true);
+                setDeletingID(submitButton.value);
+            }
+
+        }
+        if(submitButton.name === "delete"){
+            //Delete the entry
+            setIsDeleting(false);
+            response = await fetch(`/api/journal/deleteByID?id=${deletingID}`, {
+                method: "DELETE",
+            });
+            setResponseStatus(response.status);
+        }
+    };
+
+    const toggleWarningDismissed = (e:React.SyntheticEvent) => {
+        setWarningDismissed(true);
+    }
+
     return(
         <main className="wrapper">
             <Head>
                 <title>Delete Journal Entries | Mindversity Website</title>
             </Head>
             <Navigation />
-            <div className="content">
-                <h1>Posts to be deleted</h1>
+            {isDeleting && (
+                <div className="rejectModal">
+                    <div className="modalBody">
+                        <h1>Are you sure?</h1>
+                        <p>Continuing with this action will delete the entry permanently.</p>
+                        <input type='checkbox' onClick={toggleWarningDismissed}/>
+                        <span>Do not show this message again.</span>
+                        <div className="actionButtonContainer">
+                            <button type="submit" name="delete" className="actionButton actionButtonPrimary" onClick={handleEntryApproval}>Delete</button>
+                            <button className="actionButton actionButtonSecondary" onClick={() => {setIsDeleting(false); setDeletingID("")}}>Close</button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            <form className="content">
+                 {responseStatus === 200 && (
+                    <div className="success">
+                        <p>Entry successfully deleted.</p>
+                    </div>
+                )}
+                {responseStatus === 400 && (
+                    <div className="error">
+                        <p>Something went wrong. Please try again</p>
+                    </div>
+                )}
+                <h1 className="contentHeader">Posts to be deleted</h1>
+
+
                 {entries && (
                     entries.map(entry => {
                         return (
-                            <JournalEntryComponent key={entry.id} entry={entry} mode="delete"/>
+                            <JournalEntryComponent key={entry.id} entry={entry} mode="delete" handleEntryApproval={handleEntryApproval}/>
                         )
                     })
                 )}
 
-            </div>
+            </form>
             <style jsx>{`
+                 .actionButton{
+                    width: 230px;
+                    height: 50px;
+                    border-radius: 6px;
+                    font-size: 1.2rem;
+                    border: 1px solid #8C69AA;
+                    cursor:pointer;
+                    transition:0.5s ease;
+                    align-self: flex-end;
+                    margin: 10px;
+                }
+                .actionButtonPrimary {
+                    background: #8C69AA;
+                    color: white;
+                }
+                .actionButtonPrimary:hover{
+                    filter:brightness(1.2);
+                }
+                .actionButtonSecondary{
+                    background: white;
+                    color: #8C69AA;
+                }
+                .actionButtonSecondary:hover{
+                    filter:brightness(0.8);
+                }
+                .modalBody{
+                    background: white;
+                    width:500px;
+                    height:300px;
+                    padding:0.5rem;
+                    text-align:center;
+                    align-self:center;
+                }
+                .success{
+                    background: #a8ff9e;
+                    margin: 10px;
+                    border: 1px solid #095400;
+                    color: #095400;
+                    text-align:center;
+                }
+                .error{
+                    background: #ff8a82;
+                    margin: 10px;
+                    color: #590601;
+                    border: 1px solid #940900;
+                    text-align:center;
+                }
+
+
+
+                
                 @media screen and (min-width: 1000px){
                     .content {
                         margin-left: 430px;
@@ -34,16 +151,44 @@ const AdminJournalDelete: NextPage<Props> = ({entries}) => {
                         display:flex;
                         flex-direction:column;
                         height: 100vh;
+                    }   
+                    .rejectModal{
+                        width:100%;
+                        position:absolute;
+                        display:flex;
+                        flex-direction:column;
+                        justify-content:center;
+                        align-items:center;
+                        height:100%;
+                        background:rgba(0,0,0,0.2);
+                        z-index:2;
+                    }
+                    .modalBody{
+                        margin-left:430px;
+                        margin-right: 60px;
                     }
                 }
                 @media screen and (max-width: 999px){
                     .content {
-                        margin-top:30px;
                         margin-left: 30px;
                         margin-right:30px;
                         display:flex;
                         flex-direction:column;
                         height: 100vh;
+                    }   
+                    .rejectModal{
+                        width:100%;
+                        position:absolute;
+                        display:flex;
+                        flex-direction:column;
+                        justify-content:center;
+                        align-items:center;
+                        height:100%;
+                        background:rgba(0,0,0,0.2);
+                        z-index:2;
+                    }
+                    .contentHeader{
+                        text-align:center;
                     }
                 }
             `}</style>

--- a/pages/portal/journal/delete.tsx
+++ b/pages/portal/journal/delete.tsx
@@ -24,7 +24,7 @@ const AdminJournalDelete: NextPage<Props> = ({entries}) => {
 
         if(submitButton.name === "deleting"){
             if(!isDeleting && warningDismissed){
-                response = await fetch(`/api/journal/deleteByID?id=${submitButton.value}`, {
+                response = await fetch(`/api/journal/deleteById?id=${submitButton.value}`, {
                     method: "DELETE",
                 });
                 setResponseStatus(response.status);
@@ -37,7 +37,7 @@ const AdminJournalDelete: NextPage<Props> = ({entries}) => {
         if(submitButton.name === "delete"){
             //Delete the entry
             setIsDeleting(false);
-            response = await fetch(`/api/journal/deleteByID?id=${deletingID}`, {
+            response = await fetch(`/api/journal/deleteById?id=${deletingID}`, {
                 method: "DELETE",
             });
             setResponseStatus(response.status);


### PR DESCRIPTION
This PR is small, and definitely should've been included in my last PR, but it adds the backend integration for delete journals. Similar to review journals, it also displays a modal before deleting.  The API route for deleting journals is currently being worked on by Kemal, so once that's done this page should function properly. Please let me know if I need to change anything.