### PR TITLE
Login Page and Login Validation

### DIFF
--- a/pages/api/admin/validateLogin.ts
+++ b/pages/api/admin/validateLogin.ts
@@ -1,0 +1,24 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import auth from "server/actions/Authenticate";
+import { User } from "utils/types";
+import cookie from "cookie";
+
+// This is really only used to validiate when someone is logged in
+async function handler(
+    req: NextApiRequest,
+    res: NextApiResponse
+): Promise<void> {
+    try {
+        res.status(200).json({ success: true });
+    } catch (_err) {
+        const err = _err as Error;
+        res.setHeader("Set-Cookie", "auth=; Max-Age=0; SameSite=Lax; Path=/");
+        res.status(401).json({
+            success: false,
+            message: err.message,
+        });
+    }
+}
+
+// Here the auth function is run and sets the status appropriately
+export default auth('any', handler)

--- a/pages/portal/dashboard.tsx
+++ b/pages/portal/dashboard.tsx
@@ -1,7 +1,8 @@
-import { NextPage } from "next";
+import { NextPage, NextPageContext } from "next";
 import Head from "next/head";
-
 import Navigation from "components/Portal/Navigation";
+import urls from "utils/urls";
+import Router from "next/router";
 
 const Dashboard: NextPage = () => {
     return (
@@ -102,5 +103,35 @@ const Dashboard: NextPage = () => {
         </div>
     );
 };
+
+
+Dashboard.getInitialProps = async (context: NextPageContext) => {
+    const cookie = context.req?.headers.cookie
+
+    //Since this is client side only absolute URLs are supported
+    //TODO: need to change url off of localhost in production
+    const resp = await fetch("http://localhost:3000/api/admin/validateLogin", {
+        headers: {
+            cookie: cookie!
+        }
+    })
+
+    if(resp.status === 401 && !context.req) {
+        Router.replace('/portal/login')
+        return {}
+    }
+
+    if(resp.status === 401 && context.req)
+    {
+        context.res?.writeHead(302, {
+            //TODO: same here
+            Location: "http://localhost:3000/"
+        })
+        context.res?.end()
+        return {}
+    }
+
+    return {}
+}
 
 export default Dashboard;

--- a/pages/portal/index.tsx
+++ b/pages/portal/index.tsx
@@ -1,10 +1,43 @@
 import { NextPage } from "next";
 import Head from "next/head";
-
+import Router from "next/router";
 import Header from "components/Header";
 import Footer from "components/Footer";
+import { useState, useRef, FormEvent } from "react";
+import urls from "utils/urls";
 
 const Home: NextPage = () => {
+
+    let userEmail = useRef<HTMLInputElement>(null)
+    let userPassword = useRef<HTMLInputElement>(null)
+
+    let [failedLogin, setFailed] = useState(false)
+
+    let handleLogin = async (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault()
+        
+        const response = await fetch(`${urls.baseUrl}${urls.api.admin.login}`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                email: userEmail.current?.value,
+                password: userPassword.current?.value
+            })
+        })
+
+        const responseJson = await response.json()
+
+        if(responseJson?.success){
+            Router.push('/portal/dashboard')
+        } else {
+            setFailed(true)
+        }
+
+        console.log(responseJson)
+    }
+
     return (
         <div className="container">
             <Head>
@@ -18,7 +51,7 @@ const Home: NextPage = () => {
                 <div className="loginWrapper">
                     <div className="loginContainer">
                         <h1>Log In</h1>
-                        <form action="" method="post">
+                        <form onSubmit={handleLogin} action="" method="post">
                             <div className="formLabel">Email</div>
                             <input
                                 type="text"
@@ -26,6 +59,7 @@ const Home: NextPage = () => {
                                 name=""
                                 placeholder="username@email.com"
                                 id=""
+                                ref={userEmail}
                             />
                             <div className="formLabel">Password</div>
                             <input
@@ -34,11 +68,19 @@ const Home: NextPage = () => {
                                 name=""
                                 placeholder="password"
                                 id=""
+                                ref={userPassword}
                             />
                             <p className="passwordResetText">
                                 Forgot your password?{" "}
                                 <a href="/portal/password-reset">click here</a>.
                             </p>
+                            {
+                                failedLogin && (
+                                    <p className="invalidPasswordText">
+                                    Invalid Email or Password 
+                                    </p>
+                                )
+                            }
                             <div className="submitInputParent">
                                 <input
                                     type="submit"
@@ -72,6 +114,14 @@ const Home: NextPage = () => {
                     margin-top: 20px;
                     margin-bottom: 40px;
                     font-size: 34px;
+                }
+
+                .invalidPasswordText {
+                    margin-top: 10px;
+                    margin-bottom: 5px;
+                    padding-left: 80px;
+                    font-size: 14px;
+                    color: #714b92; 
                 }
 
                 .passwordResetText {

--- a/server/actions/Authenticate.ts
+++ b/server/actions/Authenticate.ts
@@ -16,7 +16,7 @@ const authenticated = (role: string, func: NextApiHandler) => async (req: NextAp
         }
 
         res.setHeader("Set-Cookie", "auth=; Max-Age=0; SameSite=Lax; Path=/");
-        res.status(500).json({ message: "Not Authenticated" });
+        res.status(401).json({ success: false, message: "Not Authenticated" });
     })
 
 }

--- a/server/actions/User.ts
+++ b/server/actions/User.ts
@@ -55,7 +55,7 @@ export async function createUser(user: User): Promise<void> {
     }
     const isNew = await checkEmail(user.email);
 
-    if (!isNew) {
+    if (isNew?._id) {
         throw Error("Email already used");
     }
 

--- a/utils/urls.ts
+++ b/utils/urls.ts
@@ -14,6 +14,7 @@ export default {
             signup: "/api/admin/signup",
             forgotPass: "/api/admin/forgotPass",
             resetPass: "/api/admin/resetPass",
+            validateLogin: "/api/admin/validateLogin",
         },
         blog: {
             get: "/api/blog/getBlog",


### PR DESCRIPTION
- In this PR I have added functionality to the login page at `/portal` while also displaying a message when an invalid login is provided
![Screen Shot 2020-12-17 at 1 02 09 AM](https://user-images.githubusercontent.com/55995260/102454359-8081c580-4003-11eb-8e74-b390c56208ef.png)

- In addition, I have added login validation to ensure that the user is logged in when accessing the dashboard, otherwise, they are redirected to the home page (we must use absolute URLs so we need to go back and remove `localhost` in production)

- Other changes include small fixes to checking if an email is already in use when signing up as well as giving a status `401` when not authenticated
