### PR TITLE
Fixed Officer Carousel, Home Chapters in Region, & Resources Page

### DIFF
--- a/components/HomeChapters/index.tsx
+++ b/components/HomeChapters/index.tsx
@@ -1,44 +1,65 @@
-import React, { useState } from "react";
+import React from "react";
 import style from "./style.module.scss";
+import { Chapter } from "utils/types";
 import { getRegion } from "utils/helpers";
 
-const HomeChapters: React.FC = () => {
+interface Props {
+  chapters: Chapter[];
+}
+
+const HomeChapters: React.FC<Props> = ({ chapters }) => {
   const [region, setRegion] = React.useState("unknown");
 
+  // If allowed, get user's coordinates to pinpoint region.
   React.useEffect(() => {
-    if (navigator) {
-      navigator.geolocation.getCurrentPosition((pos: Position) => {
+    if (navigator)
+    {
+      navigator.geolocation.getCurrentPosition((pos: GeolocationPosition) => {
         const [lat, long] = [pos.coords.latitude, pos.coords.longitude];
         setRegion(getRegion(lat, long));
       });
     }
   });
 
+  // Returns "card" element for each chapter in region.
+  const chaptersCards = chapters.filter((chapter) => chapter.region == region).map((chapter) => {
+    // Format chapter name to remove underscores.
+    var name = chapter.name?.replace(/_/g, " ");
+
+    // Get campus' picture if exists. If not, use default color.
+    var picURL, cardStyle;
+    if (chapter.campusPic?.url)
+    {
+      picURL = chapter.campusPic.url
+    } else
+    {
+      cardStyle = { backgroundColor: 'rgba(234,224,241,1.0)' }
+    }
+
+    // Chapter card elements.
+    return (
+      <a href={"chapters/" + chapter.name} className={style.card} key={JSON.stringify(chapter._id)}>
+        <div className={style.cardOverlay} style={cardStyle}>
+          <div className={style.cardText}>{name}</div>
+        </div>
+        <img
+          src={picURL}
+          className={style.cardImage}
+          alt={name}
+        ></img>
+      </a>
+    );
+  });
+  
   return (
     <div className={style.parentContainer}>
       <h2 className={style.title}>Chapters In Your Region</h2>
       <div className={style.cardWrapper}>
-        <a href="chapters" className={style.card}>
-          <div className={style.cardOverlay}>
-            <div className={style.cardText}>University of Tennessee</div>
-          </div>
-          <img
-            src="/utk-placeholder.jpg"
-            className={style.cardImage}
-            alt="Chapter name here"
-          ></img>
-        </a>
-
-        <a href="chapters" className={style.card}>
-          <div className={style.cardOverlay}>
-            <div className={style.cardText}>Rutgers</div>
-          </div>
-          <img
-            src="/rutgers-placeholder.jpg"
-            className={style.cardImage}
-            alt="Chapter name here"
-          ></img>
-        </a>
+        { chapters.filter((chapter) => chapter.region == region).length != 0
+          ? chaptersCards
+          : <h2>We were not able to locate any chapters in your region!</h2>
+          // If above message appears, no chapters in region or geolocation disabled.
+        }
       </div>
       <a href="chapters" className={style.exploreBtn}>
         Explore All

--- a/components/HomeChapters/index.tsx
+++ b/components/HomeChapters/index.tsx
@@ -9,6 +9,7 @@ interface Props {
 
 const HomeChapters: React.FC<Props> = ({ chapters }) => {
   const [region, setRegion] = React.useState("unknown");
+  const [randomChapters, setChapters] = React.useState([] as Chapter[]);
 
   // If allowed, get user's coordinates to pinpoint region.
   React.useEffect(() => {
@@ -21,8 +22,25 @@ const HomeChapters: React.FC<Props> = ({ chapters }) => {
     }
   });
 
-  // Returns "card" element for each chapter in region.
-  const chaptersCards = chapters.filter((chapter) => chapter.region == region).map((chapter) => {
+  // Used to select up to three randomized chapters after render.
+  // Must include in useEffect or will get text content mismatch error.
+  React.useEffect(() => {
+    // Create array copy to manipulate values without changing chapters prop.
+    let chaptersCopy: Chapter[] = chapters.slice();
+    // Using "Fisher-Yates shuffle" for an unbiased algorithm (unlike the easier ".sort" method).
+    for (let i = chaptersCopy.length - 1; i > 0; i--)
+    {
+      let j = Math.floor(Math.random() * (i + 1));
+      [chaptersCopy[i], chaptersCopy[j]] = [chaptersCopy[j], chaptersCopy[i]];
+    }
+
+    // Since array randomized by shuffle, just select first three in array using ".slice".
+    setChapters(chaptersCopy.slice(0,3));
+  }, []);
+
+  // Creates "card" elements for specified chapter.
+  // Used for both chapters in region and randomized chapters.
+  const createCard = (chapter: Chapter) => {
     // Format chapter name to remove underscores.
     var name = chapter.name?.replace(/_/g, " ");
 
@@ -49,16 +67,31 @@ const HomeChapters: React.FC<Props> = ({ chapters }) => {
         ></img>
       </a>
     );
+  }
+
+  // Returns "card" element for each chapter in region.
+  const chaptersCards = chapters.filter((chapter) => chapter.region == region).map((chapter) => {
+    return createCard(chapter);
+  });
+
+  // Returns "card" element for up to three random chapters.
+  // Displayed if no chapters in region or geolocation disabled.
+  const randomChapterCards = randomChapters.map((chapter) => {
+    return createCard(chapter);
   });
   
   return (
     <div className={style.parentContainer}>
-      <h2 className={style.title}>Chapters In Your Region</h2>
+      <h2 className={style.title}>
+        { chapters.filter((chapter) => chapter.region == region).length != 0
+          ? "Chapters In Your Region"
+          : "Our Chapters"
+        }
+      </h2>
       <div className={style.cardWrapper}>
         { chapters.filter((chapter) => chapter.region == region).length != 0
           ? chaptersCards
-          : <h2>We were not able to locate any chapters in your region!</h2>
-          // If above message appears, no chapters in region or geolocation disabled.
+          : randomChapterCards
         }
       </div>
       <a href="chapters" className={style.exploreBtn}>

--- a/components/OfficerCarousel/style.module.scss
+++ b/components/OfficerCarousel/style.module.scss
@@ -21,7 +21,7 @@ div.container div.imgContainer div {
   position: absolute;
   /* Slide animations */
   &.hidden {
-    opacity: 0.0;
+    opacity: 0.0 !important;
     animation: hideOfficer 0.1s linear forwards;
   }
   &.show {
@@ -34,7 +34,11 @@ div.container div.imgContainer div {
     to { transform: translateX(0); }
   }
   @keyframes hideOfficer {
-    to { transform: translateX(-100%); }
+    99% { opacity: 1.0; }
+    100% {
+      transform: translateX(-100%);
+      opacity: 0.0;
+    }
   }
   /* General styling for both picture and background */
   img {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,4 @@
-import { NextPage, NextPageContext } from "next";
+import { NextPage } from "next";
 import Head from "next/head";
 import Footer from "components/Footer";
 import Header from "components/Header";
@@ -6,14 +6,17 @@ import MainInfo from "components/MainInfo";
 import Partners from "components/Partners";
 import HomeChapters from "components/HomeChapters";
 import OfficerCarouselComp from "components/OfficerCarousel"
-import { Officer } from "utils/types";
+import { Officer, Chapter } from "utils/types";
 import { getOfficers } from "server/actions/Officer";
+import { getChapters } from "server/actions/Chapter";
 
 interface Props {
-  officers: Officer[]
+  officers: Officer[],
+  chapters: Chapter[]
 }
 
-const Home: NextPage<Props> = ({officers}) => {
+const Home: NextPage<Props> = ({officers,chapters}) => {
+
   return (
     <div className="container">
       <Head>
@@ -32,7 +35,7 @@ const Home: NextPage<Props> = ({officers}) => {
        </div>
       </div>
     }
-      <HomeChapters />
+      <HomeChapters chapters={chapters} />
       <Footer />
 
       <style jsx>{`
@@ -88,13 +91,18 @@ const Home: NextPage<Props> = ({officers}) => {
   );
 };
 
-export async function getStaticProps(context:NextPageContext) {
-  let offficerQuery: Officer = {chapter: 'national'}
-  let officers: Officer[] = await getOfficers(offficerQuery)
+export async function getStaticProps() {
+  let officerQuery: Officer = {chapter: 'national'}
+  let officers: Officer[] = await getOfficers(officerQuery)
+
+  // Get all chapters. Filter by region in component once user's location is retrieved.
+  // Navigator is undefined in async getStaticProps(), so must do it in component.
+  let chapters: Chapter[] = await getChapters({})
 
   return {
     props: {
-      officers: JSON.parse(JSON.stringify(officers))
+      officers: JSON.parse(JSON.stringify(officers)),
+      chapters: JSON.parse(JSON.stringify(chapters)),
     }
   }
 }

--- a/pages/resources/index.tsx
+++ b/pages/resources/index.tsx
@@ -71,7 +71,7 @@ const Resources: NextPage<Props> = ({resources}) => {
       <div className="heroContainer">
         <div className="textContainer">
           <h1>Resources</h1>
-          <p>Need help or want to discover something new? Use these links!.</p>
+          <p>Need help or want to discover something new? Use these links!</p>
         </div>
       </div>
 

--- a/pages/resources/index.tsx
+++ b/pages/resources/index.tsx
@@ -1,58 +1,117 @@
+import { useState } from "react";
 import { NextPage } from "next";
 import Head from "next/head";
 import Header from "components/Header";
 import Footer from "components/Footer";
+import { Resource } from "utils/types";
+import { getResource } from "server/actions/Resource";
 
-const Resources: NextPage = () => {
+interface Props {
+  resources: Resource[]
+}
+
+const Resources: NextPage<Props> = ({resources}) => {
+  // Defines number of resources to display after "Load more" button is clicked.
+  const COUNT_INCREMENT = 5;
+
+  // Tracks how many resources of each category are currently displayed for "Load more" feature.
+  const [nationalCount, setNationalCount] = useState(COUNT_INCREMENT);
+  const [mindversityCount, setMindversityCount] = useState(COUNT_INCREMENT);
+  const [helpCount, setHelpCount] = useState(COUNT_INCREMENT);
+
+  // Gets certain number of links for a specified category.
+  const getLinks = (category: string, count: number) => {
+    let links: Array<Resource> = [];
+    // Get "count" number of resources in "category."
+    for (let i = 0; i < resources.length; i++)
+    {
+      if (resources[i].category == category || (category == "national" && !resources[i].category))
+      {
+        // If specified category matches that of resource, append to its list.
+        // Also, by default, place resources with no category in the national list.
+        links.push(resources[i]);
+      }
+
+      // Once the number of appended resources matches that of how many should be loaded, stop appending.
+      if (links.length == count) break;
+    }
+
+    // Styling for links.
+    let textStyle = {
+      marginTop: "30px",
+      fontSize: "24px",
+      fontWeight: 500
+    };
+    let linkStyle = {
+      textDecoration: "none",
+      color: "#000000",
+    };
+
+    // Links elements
+    return links.map((link) => (
+      <p style={textStyle} key={category + link.link}>
+        <a style={linkStyle} href={link.link}>{link.name}</a>
+      </p>
+    ));
+  }
+
+  // Used to display certain number of "loaded" resources per category.
+  const nationalLinks = getLinks("national", nationalCount);
+  const mindversityLinks = getLinks("mindversity", mindversityCount);
+  const helpLinks = getLinks("help", helpCount);
+
   return (
     <main className="container">
       <Head>
         <title>Resources | MindVersity</title>
       </Head>
+
       <Header />
 
       <div className="heroContainer">
         <div className="textContainer">
           <h1>Resources</h1>
-          <p>Description of page content goes here</p>
+          <p>Need help or want to discover something new? Use these links!.</p>
         </div>
       </div>
 
-      <div className="contentContainer">
-        <div className="nationalResources">
-          <h2>National Resources</h2>
-          <p>
-            <a href="tel:800-273-8255">Lifeline Suicide Prevention</a>
-          </p>
-          <p>
-            <a href="https://www.nimh.nih.gov/index.shtml">
-              National Institute of Mental Health
-            </a>
-          </p>
-          <p>Hotlines</p>
-          <p>Websites</p>
+      <div className="wrapper">
+        <div className="contentContainer">
+          <div className="nationalResources">
+            <h2>National Resources</h2>
+            { nationalLinks.length != 0
+              ? nationalLinks
+              : <p>There are no resources currently. Check back again later!</p>
+            }
+            { resources.filter(resource => resource.category == "national" || resource.category == null).length > nationalCount &&
+              <button onClick={() => setNationalCount(nationalCount+COUNT_INCREMENT)}>Load more</button>
+            }
+          </div>
+          <div className="mindversityResources">
+            <h2>MindVersity Resources</h2>
+            { mindversityLinks.length != 0
+              ? mindversityLinks
+              : <p>There are no resources currently. Check back again later!</p>
+            }
+            { resources.filter(resource => resource.category == "mindversity").length > mindversityCount &&
+              <button onClick={() => setMindversityCount(mindversityCount+COUNT_INCREMENT)}>Load more</button>
+            }
+          </div>
         </div>
-
         <div className="immediateHelp">
           <h2>Immediate Help Resources</h2>
-          <p>
-            <a href="tel:800-273-8255">Help ###</a>
-          </p>
-          <p>
-            <a href="tel:">Help ###</a>
-          </p>
-          <p>Hotlines</p>
-          <p>Websites</p>
+            { helpLinks.length != 0
+              ? helpLinks
+              : <p>There are no resources currently. Check back again later!</p>
+            }
+          { resources.filter(resource => resource.category == "help").length > helpCount &&
+            <button onClick={() => setHelpCount(helpCount+COUNT_INCREMENT)}>Load more</button>
+          }
         </div>
-      </div>
-
-      <div className="mindversityResources">
-        <h2>MindVersity Resources</h2>
-        <p>Articles</p>
-        <p>Podcasts</p>
       </div>
 
       <Footer />
+
       <style jsx global>{`
         html,
         body {
@@ -70,11 +129,12 @@ const Resources: NextPage = () => {
       <style jsx>{`
         .heroContainer {
           width: 100%;
-          height: 15vh;
+          height: 30vh;
           position: relative;
           display: block;
           text-align: center;
-          margin-bottom: 20px;
+          background: rgb(234,224,241);
+          background: linear-gradient(90deg, rgba(234,224,241,1) 0%, rgba(181,156,204,1) 100%);
         }
         .textContainer {
           position: relative;
@@ -83,75 +143,91 @@ const Resources: NextPage = () => {
           transform: translateY(-50%);
         }
         .textContainer > h1 {
-          color: #8c69aa;
-          font-size: 36px;
+          color: #503E8C;
+          font-size: 41px;
           padding: 0px 20px;
         }
         .textContainer > p {
           margin-top: 0px;
           position: relative;
           display: block;
-          font-size:18px;
+          font-size: 20px;
           top: 50%;
           transform: translateY(-50%);
           padding: 0 20px;
         }
-        h2 {
-          color: #503E8C;
-          font-size: 28px;
-          font-weight: normal;
+        
+        .wrapper {
+          display: grid;
+          grid-template-columns: 1fr min-content;
+          margin: 40px 0;
         }
-        .contentContainer{
-          width: 80vw;
-          position: relative;
-          margin-left: -40vw;
-          left: 50%;
-          display:flex;
-          justify-content: space-between;
+        .contentContainer {
+          margin-left: 6vw;
         }
         .nationalResources {
-          width: 60%;
+          padding: 20px 20px;
+        }
+        .mindversityResources {
+          margin-top: 30px;
           padding: 20px 20px;
         }
         .immediateHelp {
-          width 350px;
+          width: 350px;
           background-color:#E7D8F2;
+          margin-right: 4.5vw;
           padding: 20px 20px;
         }
-        .immediateHelp > h2 {
+
+        .wrapper h2 {
+          color: #503E8C;
+          font-size: 28px;
           font-weight: bold;
         }
-        .mindversityResources {
-          width: 80vw;
-          position: relative;
-          margin-left: -40vw;
-          left: 50%;
-          padding: 20px 20px;
+        .wrapper p {
+          font-size: 24px;
+          font-weight: normal;
         }
-        a, p {
+
+        .wrapper button {
+          font-size: 20px;
+          margin-top: 10px;
+          padding: 10px 30px;
+          background-color: #8C69AA;
+          color: #FFFFFF;
+          border-radius: 15px;
           text-decoration: none;
-          color: black;
-          font-size: 1.15rem;
-          margin: 40px 0;
+          transition: background-color 0.5s;
         }
-        @media screen and (max-width: 510px) {
-          .contentContainer {
-            flex-wrap: wrap;
-            width: 100vw;
-            left: 0;
-            margin-left: 0;
-          }
-          .nationalResources,
-          .mindversityResources,
+        .wrapper button:hover {
+          cursor: pointer;
+          background-color: #503E8C;
+        }
+        .wrapper button:focus { outline: none; }
+
+        @media screen and (max-width: 860px) {
+          .wrapper { grid-template-columns: none; }
+          .contentContainer { order: 2; }
           .immediateHelp {
-            width: 100%;
-            left:0;
-            margin-left: 0;
+            order: 1;
+            width: auto;
+            margin: 0 6vw 30px 6vw;
           }
         }
       `}</style>
     </main>
   );
 };
+
+export async function getStaticProps() {
+  // Get all resources, divide into categories later.
+  let resources: Resource[] = await getResource({})
+
+  return {
+    props: {
+      resources: JSON.parse(JSON.stringify(resources))
+    }
+  }
+}
 
 export default Resources;


### PR DESCRIPTION
When looking at the national officer carousel, I noticed one of the images overlapped onto the next officer's slide due to its large width:
![overflow](https://user-images.githubusercontent.com/54458982/102570799-25f57180-40b6-11eb-95ce-3aa946931697.PNG)
To fix this, I modified the animation to hide the previous officer's image at the end.

I also used @VishalAiely 's geolocation code to only display chapters in the user's region on the home page:
![chapters](https://user-images.githubusercontent.com/54458982/102571031-9d2b0580-40b6-11eb-8219-4d236fa0d0c6.PNG)

If the chapter does not have a campus image, a default background color is applied:
![nopic](https://user-images.githubusercontent.com/54458982/102571063-afa53f00-40b6-11eb-8e3b-6149743030b8.PNG)

If no chapters are in the user's region or geolocation is not enabled, this message will appear:
![msg](https://user-images.githubusercontent.com/54458982/102571089-be8bf180-40b6-11eb-85c9-d29382f05270.PNG)

I also modified @zaviermiller 's resource page to display resources from the database. The resources are split into three different categories, "national," "mindversity," and "help." Resources with an undefined category are, by default, placed under the national category. If no resources are under a category, a message stating so appears. Also, if there are a large number of resources under one category, for example national, the user may not see another category, such as mindversity, unless they scroll all the way down. To fix this, I made it so only five resources are displayed on load. The user may view the other resources by clicking the corresponding "load more" button which displays five more each click.
![resources](https://user-images.githubusercontent.com/54458982/102571856-a0bf8c00-40b8-11eb-8b21-dc1234e1e588.PNG)

At a certain breakpoint, the immediate help resources container moves on top of the other two resources containers:
![mobile](https://user-images.githubusercontent.com/54458982/102572114-4541ce00-40b9-11eb-9bdf-d86e20fccf4a.PNG)

I also updated the banner using the same style as the chapters page banner:
![banner](https://user-images.githubusercontent.com/54458982/102572081-2ba08680-40b9-11eb-9a5f-495bb16a01f5.PNG)

Please let me know if I should make any changes.