### PR TITLE
Admin Portal Resources

### DIFF
--- a/components/Portal/ResourceCard/index.tsx
+++ b/components/Portal/ResourceCard/index.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { Resource } from "utils/types";
+import style from "./resourcecard.module.scss";
+import { ObjectID } from "mongodb";
+
+interface Props {
+    reso: Resource;
+    onDelete(id: ObjectID|undefined): void
+}
+
+const ResourceCardComp: React.FC<Props> = ({reso, onDelete}) => {
+
+
+    return (
+        <div className={style.resourceCard}>
+            <div className={style.resourceCardText}>
+                <div className={style.resourceCardTitle}>
+                    <div className={style.resourceName}>{reso.name}</div>
+                </div>
+            </div>
+            <div className={style.resourceCardBtn}>
+                <a className={style.editResourceBtn} href={"resources/" + reso._id}>Edit</a>
+            </div>
+            <div className={style.resourceCardBtn}>
+                <button className={style.editResourceBtn} onClick={() => onDelete(reso._id)} >Delete</button>
+            </div> 
+        </div>
+    )
+}
+
+export default ResourceCardComp

--- a/components/Portal/ResourceCard/index.tsx
+++ b/components/Portal/ResourceCard/index.tsx
@@ -1,31 +1,40 @@
-import React from 'react'
+import React from "react";
 import { Resource } from "utils/types";
 import style from "./resourcecard.module.scss";
 import { ObjectID } from "mongodb";
 
 interface Props {
     reso: Resource;
-    onDelete(id: ObjectID|undefined): void
+    onDelete(id: ObjectID | string | undefined): void;
 }
 
-const ResourceCardComp: React.FC<Props> = ({reso, onDelete}) => {
-
-
+const ResourceCardComp: React.FC<Props> = ({ reso, onDelete }) => {
     return (
         <div className={style.resourceCard}>
             <div className={style.resourceCardText}>
                 <div className={style.resourceCardTitle}>
                     <div className={style.resourceName}>{reso.name}</div>
+                    <div className={style.resourceLink}>{reso.link}</div>
                 </div>
             </div>
             <div className={style.resourceCardBtn}>
-                <a className={style.editResourceBtn} href={"resources/" + reso._id}>Edit</a>
+                <a
+                    className={style.editResourceBtn}
+                    href={`resources/${(reso._id as unknown) as string}`}
+                >
+                    Edit
+                </a>
             </div>
             <div className={style.resourceCardBtn}>
-                <button className={style.editResourceBtn} onClick={() => onDelete(reso._id)} >Delete</button>
-            </div> 
+                <button
+                    className={style.editResourceBtn}
+                    onClick={() => onDelete(reso._id)}
+                >
+                    Delete
+                </button>
+            </div>
         </div>
-    )
-}
+    );
+};
 
-export default ResourceCardComp
+export default ResourceCardComp;

--- a/components/Portal/ResourceCard/resourcecard.module.scss
+++ b/components/Portal/ResourceCard/resourcecard.module.scss
@@ -32,6 +32,10 @@
     text-align: left;
 }
 
+.resourceLink{
+    font-size: 16px;
+}
+
 .resourceName{
     font-size: 24px;
     font-weight: bold;

--- a/components/Portal/ResourceCard/resourcecard.module.scss
+++ b/components/Portal/ResourceCard/resourcecard.module.scss
@@ -1,0 +1,61 @@
+.resourceCard{
+    height: auto;
+    width: 100%;
+    position: relative;
+    display: flex;
+    background-color: white;
+    transition: 0.5s ease;
+    border-bottom: 1px solid black;
+    padding: 40px 0px;
+}
+
+.resourceCardText{
+    width: auto;
+    height: auto;
+    position: relative;
+    display: inline-block;
+    flex: 1;
+}
+
+.resourceCardBtn{
+    width: auto;
+    height: auto;
+    position: relative;
+    margin-left: 30px;
+    display: inline-block;
+    text-align: right;
+    flex: 0;
+}
+
+.resourceCardTitle{
+    height: auto;
+    text-align: left;
+}
+
+.resourceName{
+    font-size: 24px;
+    font-weight: bold;
+    color: #8C69AA;
+}
+
+.editResourceBtn {
+    height: auto;
+    width: auto;
+    padding: 10px 40px;
+    position: relative;
+    display: inline-block;
+    border: none;
+    font-size: 16px;
+    margin-top: 20px;
+    outline: none;
+    border-radius: 6px;
+    background-color: #8c69aa;
+    color: white;
+    text-decoration: none;
+    transition: background 0.5s ease;
+}
+
+.editResourceBtn:hover {
+    cursor: pointer;
+    background-color: #b59ccc;
+}

--- a/pages/portal/journal/delete.tsx
+++ b/pages/portal/journal/delete.tsx
@@ -214,7 +214,8 @@ AdminJournalDelete.getInitialProps = async (context: NextPageContext) => {
     const response = await fetch(url, {
         method: "GET",
     });
-    let entries = await response.json();
+    let json = await response.json();
+    let entries: JournalEntry[] = json.payload
     
     return{
         entries,

--- a/pages/portal/journal/review.tsx
+++ b/pages/portal/journal/review.tsx
@@ -227,7 +227,8 @@ AdminJournalReview.getInitialProps = async (context: NextPageContext) => {
     const response = await fetch(url, {
         method: "GET",
     });
-    let entries: JournalEntry[] = await response.json();
+    let json = await response.json();
+    let entries: JournalEntry[] = json.payload
     return{
         entries,
     }

--- a/pages/portal/resources/[id].tsx
+++ b/pages/portal/resources/[id].tsx
@@ -57,7 +57,7 @@ const editResourcePage: NextPage<Props> = ({resource}) => {
                         <label htmlFor="name">Resource Name</label>
                         <input ref={nameEle} type="text" name="name" placeholder="Resource Name" defaultValue={resource.name} required/>
                         <label htmlFor="category">Category</label>
-                        <select ref={cateEle} name="category" id="categoryChoice" defaultValue={resource.category || "National"}>
+                        <select ref={cateEle} name="category" id="categoryChoice" defaultValue={resource.category || "national"}>
                             <option value="national">National</option>
                             <option value="mindversity">Mindversity</option>
                             <option value="help">Help</option>

--- a/pages/portal/resources/[id].tsx
+++ b/pages/portal/resources/[id].tsx
@@ -1,0 +1,182 @@
+import { NextPage, NextPageContext } from 'next'
+import Head from "next/head";
+import React, { useRef, FormEvent } from 'react'
+import { Resource } from 'utils/types'
+import { getResources } from "requests/Resource";
+import Navigation from "components/Portal/Navigation";
+import Router from 'next/router';
+import urls from 'utils/urls'
+
+interface Props {
+    resource: Resource;
+}
+
+
+const editResourcePage: NextPage<Props> = ({resource}) => {
+
+    const nameEle = useRef<HTMLInputElement>(null)
+    const cateEle = useRef<HTMLSelectElement>(null)
+    const linkEle = useRef<HTMLInputElement>(null)
+
+    const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+        e.preventDefault()
+
+        const chagedResource: Resource = {
+            _id: resource._id,
+            name: nameEle.current?.value,
+            category: cateEle.current?.value,
+            link: linkEle.current?.value,
+        }
+
+        const response = await fetch(`${urls.baseUrl}${urls.api.resource.update}`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(chagedResource)
+        })
+
+        Router.push('/portal/resources')
+    }
+
+
+    return (
+        <div className="container">
+
+        <Head>
+            <title>MindVersity | Admin Portal</title>
+            <link rel="icon" href="/favicon.ico" />
+        </Head>
+
+        <Navigation />
+
+        <div className="bodyContent">
+                <h1>Edit Resource</h1>
+                <div className="formContainer">
+                    <form onSubmit={handleSubmit} method="post">
+                        <label htmlFor="name">Resource Name</label>
+                        <input ref={nameEle} type="text" name="name" placeholder="Resource Name" defaultValue={resource.name} required/>
+                        <label htmlFor="category">Category</label>
+                        <select ref={cateEle} name="category" id="categoryChoice" defaultValue={resource.category || "National"}>
+                            <option value="national">National</option>
+                            <option value="mindversity">Mindversity</option>
+                            <option value="help">Help</option>
+                        </select>
+                        <label htmlFor="linkornumber">Link or Phone Number</label>
+                        <input ref={linkEle} type="text" name="link" placeholder="Link or Phone Number" defaultValue={resource.link}/>
+                        <input type="submit" value="Update" className="submitInput"/>
+                    </form>
+                </div>
+            </div>
+
+            <style jsx>{`
+            .container{
+                padding-top: 50px;
+                text-align: left;
+            }
+
+            @media screen and (min-width: 1000px){
+                .bodyContent{
+                    width: auto;
+                    height: auto;
+                    position: relative;
+                    display: body;
+                    margin-left: 375px;
+                }
+            }
+
+            h1{
+                color: black;
+                padding: 0px 40px;
+            }
+
+            .formContainer{
+                width: 100%;
+                height: auto;
+                position: relative;
+                display: block;
+                padding: 20px 40px;
+                text-align: center;
+            }
+
+            input[type=text], select, textarea {
+                height: auto;
+                width: 75%;
+                padding: 10px 15px;
+                position: relative;
+                display: block;
+                border: none;
+                font-size: 16px;
+                margin-bottom: 15px;
+                outline: none;
+                border-radius: 5px;
+                background-color: #eae0f1;
+                font-family: inherit;
+            }
+
+            textarea{
+                min-height: 150px;
+                resize: vertical;
+            }
+
+            label{
+                display: block;
+                margin-bottom: 5px;
+                padding-left: 5px;
+                text-align: left;
+                font-size: 16px;
+            }
+
+            .submitInput {
+                height: auto;
+                width: auto;
+                padding: 10px 40px;
+                position: relative;
+                display: block;
+                border: none;
+                font-size: 16px;
+                margin-top: 40px;
+                outline: none;
+                border-radius: 6px;
+                background-color: #8c69aa;
+                color: white;
+                transition: background 0.5s ease;
+            }
+
+            .submitInput:hover {
+                cursor: pointer;
+                background-color: #b59ccc;
+            }
+            `}</style>
+
+            <style jsx global>{`
+            html,
+            body {
+                padding: 0;
+                margin: 0;
+                font-family: -apple-system, BlinkMacSystemFont, Segoe UI,
+                    Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans,
+                    Helvetica Neue, sans-serif;
+            }
+            * {
+                box-sizing: border-box;
+            }
+            `}</style>
+        </div>
+    )
+}
+
+editResourcePage.getInitialProps = async (context: NextPageContext) => {
+    let resourceQuery: Resource = {_id: context.query.id as string}
+    let resource: Resource[] = await getResources(resourceQuery)
+
+    if(resource.length === 0) {
+        Router.replace('/portal/dashboard')
+    }
+
+    return {
+        resource: resource[0]
+    }
+}
+
+export default editResourcePage;

--- a/pages/portal/resources/create.tsx
+++ b/pages/portal/resources/create.tsx
@@ -1,14 +1,13 @@
-import { NextPage, NextPageContext } from 'next'
+import { NextPage } from 'next'
 import Head from "next/head";
 import React, { useRef, FormEvent } from 'react'
 import { Resource } from 'utils/types'
-import { getResources } from "requests/Resource";
 import Navigation from "components/Portal/Navigation";
 import Router from 'next/router';
 import urls from 'utils/urls'
 
 
-const createResourcePage: NextPage = () => {
+const CreateResourcePage: NextPage = () => {
 
     const nameEle = useRef<HTMLInputElement>(null)
     const cateEle = useRef<HTMLSelectElement>(null)
@@ -23,7 +22,7 @@ const createResourcePage: NextPage = () => {
             link: linkEle.current?.value,
         }
 
-        const response = await fetch(`${urls.baseUrl}${urls.api.resource.add}`, {
+        const response = await fetch(`${urls.baseUrl as string}${urls.api.resource.add as string}`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'
@@ -46,7 +45,7 @@ const createResourcePage: NextPage = () => {
         <Navigation />
 
         <div className="bodyContent">
-                <h1>Edit Resource</h1>
+                <h1>Create Resource</h1>
                 <div className="formContainer">
                     <form onSubmit={handleSubmit} method="post">
                         <label htmlFor="name">Resource Name</label>
@@ -161,4 +160,4 @@ const createResourcePage: NextPage = () => {
     )
 }
 
-export default createResourcePage;
+export default CreateResourcePage;

--- a/pages/portal/resources/create.tsx
+++ b/pages/portal/resources/create.tsx
@@ -1,0 +1,164 @@
+import { NextPage, NextPageContext } from 'next'
+import Head from "next/head";
+import React, { useRef, FormEvent } from 'react'
+import { Resource } from 'utils/types'
+import { getResources } from "requests/Resource";
+import Navigation from "components/Portal/Navigation";
+import Router from 'next/router';
+import urls from 'utils/urls'
+
+
+const createResourcePage: NextPage = () => {
+
+    const nameEle = useRef<HTMLInputElement>(null)
+    const cateEle = useRef<HTMLSelectElement>(null)
+    const linkEle = useRef<HTMLInputElement>(null)
+
+    const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+        e.preventDefault()
+
+        const newResource: Resource = {
+            name: nameEle.current?.value,
+            category: cateEle.current?.value,
+            link: linkEle.current?.value,
+        }
+
+        const response = await fetch(`${urls.baseUrl}${urls.api.resource.add}`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(newResource)
+        })
+
+        Router.push('/portal/resources')
+    }
+
+
+    return (
+        <div className="container">
+
+        <Head>
+            <title>MindVersity | Admin Portal</title>
+            <link rel="icon" href="/favicon.ico" />
+        </Head>
+
+        <Navigation />
+
+        <div className="bodyContent">
+                <h1>Edit Resource</h1>
+                <div className="formContainer">
+                    <form onSubmit={handleSubmit} method="post">
+                        <label htmlFor="name">Resource Name</label>
+                        <input ref={nameEle} type="text" name="name" placeholder="Resource Name"  required/>
+                        <label htmlFor="category">Category</label>
+                        <select ref={cateEle} name="category" id="categoryChoice" >
+                            <option value="national">National</option>
+                            <option value="mindversity">Mindversity</option>
+                            <option value="help">Help</option>
+                        </select>
+                        <label htmlFor="linkornumber">Link or Phone Number</label>
+                        <input ref={linkEle} type="text" name="link" placeholder="Link or Phone Number" />
+                        <input type="submit" value="Create" className="submitInput"/>
+                    </form>
+                </div>
+            </div>
+
+            <style jsx>{`
+            .container{
+                padding-top: 50px;
+                text-align: left;
+            }
+
+            @media screen and (min-width: 1000px){
+                .bodyContent{
+                    width: auto;
+                    height: auto;
+                    position: relative;
+                    display: body;
+                    margin-left: 375px;
+                }
+            }
+
+            h1{
+                color: black;
+                padding: 0px 40px;
+            }
+
+            .formContainer{
+                width: 100%;
+                height: auto;
+                position: relative;
+                display: block;
+                padding: 20px 40px;
+                text-align: center;
+            }
+
+            input[type=text], select, textarea {
+                height: auto;
+                width: 75%;
+                padding: 10px 15px;
+                position: relative;
+                display: block;
+                border: none;
+                font-size: 16px;
+                margin-bottom: 15px;
+                outline: none;
+                border-radius: 5px;
+                background-color: #eae0f1;
+                font-family: inherit;
+            }
+
+            textarea{
+                min-height: 150px;
+                resize: vertical;
+            }
+
+            label{
+                display: block;
+                margin-bottom: 5px;
+                padding-left: 5px;
+                text-align: left;
+                font-size: 16px;
+            }
+
+            .submitInput {
+                height: auto;
+                width: auto;
+                padding: 10px 40px;
+                position: relative;
+                display: block;
+                border: none;
+                font-size: 16px;
+                margin-top: 40px;
+                outline: none;
+                border-radius: 6px;
+                background-color: #8c69aa;
+                color: white;
+                transition: background 0.5s ease;
+            }
+
+            .submitInput:hover {
+                cursor: pointer;
+                background-color: #b59ccc;
+            }
+            `}</style>
+
+            <style jsx global>{`
+            html,
+            body {
+                padding: 0;
+                margin: 0;
+                font-family: -apple-system, BlinkMacSystemFont, Segoe UI,
+                    Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans,
+                    Helvetica Neue, sans-serif;
+            }
+            * {
+                box-sizing: border-box;
+            }
+            `}</style>
+        </div>
+    )
+}
+
+export default createResourcePage;

--- a/pages/portal/resources/index.tsx
+++ b/pages/portal/resources/index.tsx
@@ -1,0 +1,130 @@
+import { NextPage, NextPageContext } from "next";
+import Head from "next/head";
+import { getResources } from "requests/Resource";
+import { Resource } from 'utils/types';
+
+import Navigation from "components/Portal/Navigation";
+import ChapterCard from "components/Portal/ChapterCard";
+
+interface Props {
+    resource: Resource[];
+}
+
+const Resources: NextPage<Props> = ({resource}) => {
+    return (
+        <div className="container">
+            <Head>
+                <title>MindVersity | Admin Portal</title>
+                <link rel="icon" href="/favicon.ico" />
+            </Head>
+
+            <Navigation />
+
+            <div className="bodyContent">
+                <h1>Edit Resources</h1>
+                <div className="newResourceBtnParent">
+                    <a href="resource/create" className="newResourceBtn">New Resource</a>
+                </div>
+                <div className="resourcesContainer">
+                    {
+                        resource && (
+                            resource.map(reso => {
+                                return (
+                                    <p>{reso.name}</p>
+                                )
+                            })
+                        )
+                    }
+                </div>
+                
+            </div>
+
+            <style jsx>{`
+                .container{
+                    padding-top: 50px;
+                    text-align: left;
+                }
+
+                @media screen and (min-width: 1000px){
+                    .bodyContent{
+                        width: auto;
+                        height: auto;
+                        position: relative;
+                        display: body;
+                        margin-left: 375px;
+                    }
+                }
+
+                h1{
+                    color: black;
+                    padding: 0px 40px;
+                }
+
+                .newResourceBtnParent {
+                    width: auto;
+                    height: auto;
+                    position: relative;
+                    display: block;
+                    text-align: left;
+                    padding: 0px 40px;
+                    margin-bottom: 20px;
+                }
+
+                .newResourceBtn {
+                    height: auto;
+                    width: auto;
+                    padding: 10px 40px;
+                    position: relative;
+                    display: inline-block;
+                    border: none;
+                    font-size: 16px;
+                    margin-top: 20px;
+                    outline: none;
+                    border-radius: 6px;
+                    background-color: #8c69aa;
+                    color: white;
+                    text-decoration: none;
+                    transition: background 0.5s ease;
+                }
+
+                .newResourceBtn:hover {
+                    cursor: pointer;
+                    background-color: #b59ccc;
+                }
+
+                .resourcesContainer{
+                    width: 100%;
+                    height: auto;
+                    position: relative;
+                    display: block;
+                    padding: 20px 40px;
+                    text-align: center;
+                }
+            `}</style>
+
+            <style jsx global>{`
+                html,
+                body {
+                    padding: 0;
+                    margin: 0;
+                    font-family: -apple-system, BlinkMacSystemFont, Segoe UI,
+                        Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans,
+                        Helvetica Neue, sans-serif;
+                }
+                * {
+                    box-sizing: border-box;
+                }
+            `}</style>
+        </div>
+    );
+};
+
+Resources.getInitialProps = async ( context: NextPageContext ) => {
+    let resources: Resource[] = await getResources({})
+    //Return an array of the chapters
+    return {
+        resource: resources
+    }
+}
+
+export default Resources;

--- a/pages/portal/resources/index.tsx
+++ b/pages/portal/resources/index.tsx
@@ -2,15 +2,26 @@ import { NextPage, NextPageContext } from "next";
 import Head from "next/head";
 import { getResources } from "requests/Resource";
 import { Resource } from 'utils/types';
-
+import { ObjectID } from "mongodb";
 import Navigation from "components/Portal/Navigation";
-import ChapterCard from "components/Portal/ChapterCard";
+import ResourceCardComp from "components/Portal/ResourceCard";
+import { useState } from "react";
 
 interface Props {
     resource: Resource[];
 }
 
 const Resources: NextPage<Props> = ({resource}) => {
+
+    let [resourcesList, setResourceList] = useState(resource)
+
+    let handleDelete = (id: ObjectID|undefined) => {
+        if(id === undefined) return
+        
+        const newResourceList = resourcesList.filter(resourceItem => resourceItem._id !== id)
+        setResourceList(newResourceList)
+    }
+
     return (
         <div className="container">
             <Head>
@@ -27,10 +38,10 @@ const Resources: NextPage<Props> = ({resource}) => {
                 </div>
                 <div className="resourcesContainer">
                     {
-                        resource && (
-                            resource.map(reso => {
+                        resourcesList && (
+                            resourcesList.map((reso, i) => {
                                 return (
-                                    <p>{reso.name}</p>
+                                    <ResourceCardComp key={i} reso={reso} onDelete={handleDelete}/>
                                 )
                             })
                         )

--- a/pages/portal/resources/index.tsx
+++ b/pages/portal/resources/index.tsx
@@ -6,6 +6,7 @@ import { ObjectID } from "mongodb";
 import Navigation from "components/Portal/Navigation";
 import ResourceCardComp from "components/Portal/ResourceCard";
 import { useState } from "react";
+import urls from "utils/urls";
 
 interface Props {
     resource: Resource[];
@@ -15,9 +16,19 @@ const Resources: NextPage<Props> = ({resource}) => {
 
     let [resourcesList, setResourceList] = useState(resource)
 
-    let handleDelete = (id: ObjectID|undefined) => {
+    let handleDelete = async (id: ObjectID|undefined) => {
         if(id === undefined) return
         
+        const response = await fetch(`${urls.baseUrl}${urls.api.resource.delete}`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                _id: id
+            })
+        })
+
         const newResourceList = resourcesList.filter(resourceItem => resourceItem._id !== id)
         setResourceList(newResourceList)
     }
@@ -34,7 +45,7 @@ const Resources: NextPage<Props> = ({resource}) => {
             <div className="bodyContent">
                 <h1>Edit Resources</h1>
                 <div className="newResourceBtnParent">
-                    <a href="resource/create" className="newResourceBtn">New Resource</a>
+                    <a href="resources/create" className="newResourceBtn">New Resource</a>
                 </div>
                 <div className="resourcesContainer">
                     {

--- a/requests/Resource.ts
+++ b/requests/Resource.ts
@@ -1,0 +1,77 @@
+import fetch from "isomorphic-unfetch"
+import { Resource } from "utils/types";
+
+export const getResources = async (resource: Resource) => 
+    fetch('http://localhost:3000/api/resource/getResource', {
+        method: "POST",
+        mode: "same-origin",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify(resource)
+    }).then(response => response.json()).then((json) => {
+        if (json == null) {
+            throw new Error("Could not connect to API!");
+        } else if (!json.success) {
+            throw new Error(json.message);
+        }
+
+        return json.resources;
+    });
+
+
+export const addResources = async (resource: Resource) => {
+    fetch('http://localhost:3000/api/resource/addResource', {
+        method: "POST",
+        mode: "same-origin",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify(resource)
+    }).then(response => response.json()).then((json) => {
+        if (json == null) {
+            throw new Error("Could not connect to API!");
+        } else if (!json.success) {
+            throw new Error(json.message);
+        }
+
+        return json.resources;
+    })
+}
+export const deleteResources = async (resource: Resource) => {
+    fetch('http://localhost:3000/api/resource/deleteResource', {
+        method: "POST",
+        mode: "same-origin",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify(resource)
+    }).then(response => response.json()).then((json) => {
+        if (json == null) {
+            throw new Error("Could not connect to API!");
+        } else if (!json.success) {
+            throw new Error(json.message);
+        }
+
+        return json.resources;
+    })
+}
+
+export const updateResources = async (resource: Resource) => {
+    fetch('http://localhost:3000/api/resource/updateResource', {
+        method: "POST",
+        mode: "same-origin",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify(resource)
+    }).then(response => response.json()).then((json) => {
+        if (json == null) {
+            throw new Error("Could not connect to API!");
+        } else if (!json.success) {
+            throw new Error(json.message);
+        }
+
+        return json.resources;
+    })
+}

--- a/server/actions/Resource.ts
+++ b/server/actions/Resource.ts
@@ -46,11 +46,11 @@ export const getResource = async function (
 export const updateResource = async function (
     resource: Resource
 ): Promise<boolean> {
-    if (!resource.id) throw new Error("Id must be provided for update");
+    if (!resource._id) throw new Error("Id must be provided for update");
 
     await mongoDB();
 
-    const oldResource = { _id: resource.id };
+    const oldResource = { _id: resource._id };
 
     if (
         await ResourceModel.findOneAndUpdate(oldResource, resource, {
@@ -74,8 +74,8 @@ export const deleteResource = async function (
     await mongoDB();
     let deleted = false;
 
-    if (resource.id) {
-        await ResourceModel.findByIdAndDelete(resource.id).then(
+    if (resource._id) {
+        await ResourceModel.findByIdAndDelete(resource._id).then(
             (resource: Resource) => {
                 if (resource) deleted = true;
             }

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -36,7 +36,7 @@ export interface ContentfulImage {
 }
 
 export interface Resource {
-    _id?: ObjectID;
+    _id?: ObjectID|string;
     name?: string;
     category?: string;
     link?: string;

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -36,7 +36,7 @@ export interface ContentfulImage {
 }
 
 export interface Resource {
-    id?: ObjectID;
+    _id?: ObjectID;
     name?: string;
     category?: string;
     link?: string;

--- a/utils/urls.ts
+++ b/utils/urls.ts
@@ -26,6 +26,12 @@ export default {
         },
         officer: {
             get: "/api/officer/getOfficers",
-        }
+        },
+        resource: {
+            add: "/api/resource/addResource",
+            get: "/api/resource/getResource",
+            update: "/api/resource/updateResource",
+            delete: "/api/resource/deleteResource",
+        },
     },
 };


### PR DESCRIPTION
Admin Portal Resources Management
---
Let me know if these changes broke anything or don't look right
### Changes
- Added list of resources pulled from the database to display on Edit Resource pages under `/portal/resources` used styling from @rluberto chapter page
    -  A new component (largely based on @rluberto code for the chapter list on the admin page) to modify resources
- Added a page to create a new resource and edit a previously added resource
- Added the ability to delete a resource from the admin portal
- Changed the type `Resource` to now use the property name `_id` instead of `id` for consistency with mongoose and allowed it to be a string to easier parsing from query parameters

### Fixes
- Changed Journal portion of admin dashboard (in `getInitialProps`) to use the responses payload after API change
    - `pages/portal/journal/delete.tsx`
    -  `pages/portal/journal/review.tsx`

### Screenshots
- #### Resources List
![Resources List](https://user-images.githubusercontent.com/55995260/102682414-e8184c00-418e-11eb-97b6-531160f1f73e.png)
- #### Create Resource View
![Create Resource View](https://user-images.githubusercontent.com/55995260/102682439-126a0980-418f-11eb-9391-85bb1fc69677.png)

