### PR TITLE
Protect Admin Pages

### DIFF
--- a/components/Portal/JournalEntry/index.tsx
+++ b/components/Portal/JournalEntry/index.tsx
@@ -1,29 +1,61 @@
 import styles from "./journalentry.module.scss";
-import {JournalEntry} from "utils/types";
-interface Props{
+import { JournalEntry } from "utils/types";
+import urls from "utils/urls";
+
+interface Props {
     entry: JournalEntry;
     mode: string; //Because Delete Journal and Update Journal require a similar component, this prop allows us to swap out things needed in each inside this component. This keeps us from having to make two components that are basically the same thing. There's two modes: delete and review.
-    handleEntryApproval: any;
+    handleEntryApproval(e: React.SyntheticEvent): void;
 }
-const JournalEntryComponent: React.FC<Props> = ({entry, mode, handleEntryApproval}) => {
-    return(
-        <div className={styles['entry']}>
-            <div className={styles['entryBody']}>
-                <h1 className={styles['title']}>{entry.title}</h1>
-                <p className={styles['description']}>{entry.description}</p>
+const JournalEntryComponent: React.FC<Props> = ({ entry, mode, handleEntryApproval }) => {
+    return (
+        <div className={styles["entry"]}>
+            <div className={styles["entryBody"]}>
+                <a
+                    href={`${urls.baseUrl}${urls.pages.journal.index}/${entry.id || ""}`}
+                    target="_blank"
+                    rel="noreferrer"
+                    className={styles["title"]}
+                >
+                    {entry.title}
+                </a>
+                <p className={styles["description"]}>{entry.description}</p>
             </div>
-            <div className={styles['actionButtonContainer']}>
-                { mode === "delete" && (
-                    <button name="deleting" className={`${styles['actionButton']} ${styles['actionButtonPrimary']}`} onClick={(e) => handleEntryApproval(e)} value={entry.id}>Delete</button>
-                ) }
-                { mode === "review" && (
+            <div className={styles["actionButtonContainer"]}>
+                {mode === "delete" && (
+                    <button
+                        name="deleting"
+                        className={`${styles["actionButton"]} ${styles["actionButtonPrimary"]}`}
+                        onClick={e => handleEntryApproval(e)}
+                        value={entry.id}
+                    >
+                        Delete
+                    </button>
+                )}
+                {mode === "review" && (
                     <div>
-                        <button name="approve" type="submit" className={`${styles['actionButtonPrimary']} ${styles['actionButton']}`} onClick={(e:React.SyntheticEvent) => handleEntryApproval(e)} value={entry.id}>Approve</button>
-                        <button name="rejecting" type="submit" className={`${styles['actionButtonSecondary']} ${styles['actionButton']}`} onClick={(e:React.SyntheticEvent) => handleEntryApproval(e)} value={entry.id}>Reject</button>
+                        <button
+                            name="approve"
+                            type="submit"
+                            className={`${styles["actionButtonPrimary"]} ${styles["actionButton"]}`}
+                            onClick={(e: React.SyntheticEvent) => handleEntryApproval(e)}
+                            value={entry.id}
+                        >
+                            Approve
+                        </button>
+                        <button
+                            name="rejecting"
+                            type="submit"
+                            className={`${styles["actionButtonSecondary"]} ${styles["actionButton"]}`}
+                            onClick={(e: React.SyntheticEvent) => handleEntryApproval(e)}
+                            value={entry.id}
+                        >
+                            Reject
+                        </button>
                     </div>
-                ) }
+                )}
             </div>
         </div>
-    )
+    );
 };
 export default JournalEntryComponent;

--- a/components/Portal/JournalEntry/journalentry.module.scss
+++ b/components/Portal/JournalEntry/journalentry.module.scss
@@ -16,6 +16,7 @@ $color: #8C69AA;
     font-size: 2rem;
     color: $color;
     margin-bottom:0;
+    text-decoration: none;
 }
 .description{
     color: #2B2B2C;

--- a/components/Portal/Navigation/index.tsx
+++ b/components/Portal/Navigation/index.tsx
@@ -5,7 +5,20 @@ import style from "./navigation.module.scss"; //Import the main stylesheet
 import { AiOutlineMenu } from "react-icons/ai";
 import { HiOutlineBookOpen } from "react-icons/hi";
 import { FiPenTool, FiAward } from "react-icons/fi";
-import {RiDeleteBin2Line} from "react-icons/ri";
+import { RiDeleteBin2Line } from "react-icons/ri";
+import Router from "next/router";
+import urls from "utils/urls";
+
+const handleSignout = async () => {
+    await fetch(`${urls.baseUrl}${urls.api.admin.signout}`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+    });
+    void Router.push("/");
+};
+
 const Navigation: React.FC = () => {
     const [open, setOpen] = useState(false); //Control the state of the mobile navigation menu
 
@@ -50,9 +63,15 @@ const Navigation: React.FC = () => {
                             </a>
                         </div>
                     </div>
+                    <div className={style.navLowerLinks}>
+                        <div className={style.navLowerCol}>
+                            <button className={style.signoutBtn} onClick={handleSignout}>
+                                Sign Out
+                            </button>
+                        </div>
+                    </div>
                     <div className={style.navLowerText}>
-                        A Global Effort to Better BIPOC Student Mental Health
-                        Care.
+                        A Global Effort to Better BIPOC Student Mental Health Care.
                     </div>
                 </div>
             </div>
@@ -61,10 +80,7 @@ const Navigation: React.FC = () => {
                 className={open ? style["overlayOpen"] : style["overlayClosed"]}
                 onClick={() => setOpen(!open)}
             ></div>
-            <button
-                className={style.hamburgerMenu}
-                onClick={() => setOpen(!open)}
-            >
+            <button className={style.hamburgerMenu} onClick={() => setOpen(!open)}>
                 <AiOutlineMenu />
             </button>
         </div>

--- a/components/Portal/Navigation/navigation.module.scss
+++ b/components/Portal/Navigation/navigation.module.scss
@@ -161,3 +161,17 @@
     color: #E7D8F2;
     text-align: left;
 }
+
+.signoutBtn{
+    background: none!important;
+    border: none;
+    padding: 0!important;
+    position: relative;
+    display: block;
+    color: white;
+    text-align: left;
+    text-decoration: none;
+    font-size: 20px;
+    margin-bottom: 10px;
+    cursor: pointer;
+}

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "husky": "^4.2.5",
         "lint-staged": "^10.2.7",
         "prettier": "^2.0.5",
-        "typescript": "^3.9.3"
+        "typescript": "^4.1.3"
     },
     "husky": {
         "hooks": {

--- a/pages/api/admin/signout.ts
+++ b/pages/api/admin/signout.ts
@@ -1,0 +1,19 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
+    try {
+        res.setHeader("Set-Cookie", "auth=; Max-Age=0; SameSite=Lax; Path=/");
+
+        res.status(200).json({
+            success: true,
+            payload: {},
+        });
+    } catch (error) {
+        const err = error as Error;
+
+        res.status(400).json({
+            success: false,
+            message: err.message,
+        });
+    }
+}

--- a/pages/api/resource/addResource.ts
+++ b/pages/api/resource/addResource.ts
@@ -6,17 +6,17 @@ import { Resource } from "utils/types";
 export default auth("admin", async function handler(req: NextApiRequest, res: NextApiResponse) {
     try {
         const resourceData = req.body as Resource;
-        await addResource(resource);
-        res.status(200).json({ 
-            success: true, 
-            payload: {}
+        await addResource(resourceData);
+        res.status(200).json({
+            success: true,
+            payload: {},
         });
-    } 
-    catch (error) {
-        console.error(error);
+    } catch (error) {
+        const err = error as Error;
+        console.error(err);
         res.status(400).json({
             success: false,
-            message: error.message
+            message: err.message,
         });
     }
 });

--- a/pages/portal/chapters/[name].tsx
+++ b/pages/portal/chapters/[name].tsx
@@ -1,5 +1,6 @@
 import { NextPage, NextPageContext } from "next";
 import Router from "next/router";
+import urls from "utils/urls";
 
 const nameChapterPage: NextPage = () => {
     return <div></div>;
@@ -8,23 +9,20 @@ const nameChapterPage: NextPage = () => {
 export async function getServerSideProps(context: NextPageContext) {
     const cookie = context.req?.headers.cookie;
 
-    //Since this is client side only absolute URLs are supported
-    //TODO: need to change url off of localhost in production
-    const resp = await fetch("http://localhost:3000/api/admin/validateLogin", {
+    const resp = await fetch(`${urls.baseUrl}${urls.api.admin.validateLogin}`, {
         headers: {
             cookie: cookie!,
         },
     });
 
     if (resp.status === 401 && !context.req) {
-        void Router.replace("/portal/login");
+        void Router.replace(`${urls.pages.portal.login}`);
         return { props: {} };
     }
 
     if (resp.status === 401 && context.req) {
         context.res?.writeHead(302, {
-            //TODO: same here
-            Location: "http://localhost:3000/",
+            Location: `${urls.baseUrl}`,
         });
         context.res?.end();
         return { props: {} };

--- a/pages/portal/chapters/[name].tsx
+++ b/pages/portal/chapters/[name].tsx
@@ -1,11 +1,36 @@
-import { NextPage } from "next";
+import { NextPage, NextPageContext } from "next";
+import Router from "next/router";
 
 const nameChapterPage: NextPage = () => {
-    return(
-        <div>
+    return <div></div>;
+};
 
-        </div>
-    )
+export async function getServerSideProps(context: NextPageContext) {
+    const cookie = context.req?.headers.cookie;
+
+    //Since this is client side only absolute URLs are supported
+    //TODO: need to change url off of localhost in production
+    const resp = await fetch("http://localhost:3000/api/admin/validateLogin", {
+        headers: {
+            cookie: cookie!,
+        },
+    });
+
+    if (resp.status === 401 && !context.req) {
+        void Router.replace("/portal/login");
+        return { props: {} };
+    }
+
+    if (resp.status === 401 && context.req) {
+        context.res?.writeHead(302, {
+            //TODO: same here
+            Location: "http://localhost:3000/",
+        });
+        context.res?.end();
+        return { props: {} };
+    }
+
+    return { props: {} };
 }
 
 export default nameChapterPage;

--- a/pages/portal/chapters/create.tsx
+++ b/pages/portal/chapters/create.tsx
@@ -1,17 +1,19 @@
-import { NextPage } from "next";
+import { NextPage, NextPageContext } from "next";
 import Head from "next/head";
 import { addChapter } from "requests/Chapter";
-import { Chapter } from 'utils/types';
+import { Chapter } from "utils/types";
 
 import Navigation from "components/Portal/Navigation";
+import Router from "next/router";
+import { FormEvent } from "react";
 
-const handleSubmit = async (e:any) => {
+const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const formData = new FormData(e.target);
-    var chapter: Chapter = await addChapter(formData);
+    const formData = new FormData(e.currentTarget);
+    const chapter: Chapter = (await addChapter(formData)) as Chapter;
     //After submitting the form send the user to the chapter edit page
-    var chapterName = String(formData.get("name"));
-    window.location.href = chapterName?.replace(/ /g, "_")
+    const chapterName = String(formData.get("name"));
+    window.location.href = chapterName?.replace(/ /g, "_");
 };
 
 const Chapters: NextPage = () => {
@@ -29,7 +31,7 @@ const Chapters: NextPage = () => {
                 <div className="formContainer">
                     <form onSubmit={handleSubmit} method="post">
                         <label htmlFor="name">Chapter Name</label>
-                        <input type="text" name="name" placeholder="Chapter Name" required/>
+                        <input type="text" name="name" placeholder="Chapter Name" required />
                         <label htmlFor="region">Region</label>
                         <select name="region" id="">
                             <option value="northeast">Northeast</option>
@@ -38,28 +40,28 @@ const Chapters: NextPage = () => {
                             <option value="midwest">Midwest</option>
                         </select>
                         <label htmlFor="city">City</label>
-                        <input type="text" name="city" placeholder="City"/>
+                        <input type="text" name="city" placeholder="City" />
                         <label htmlFor="state">State</label>
-                        <input type="text" name="state" placeholder="State"/>
+                        <input type="text" name="state" placeholder="State" />
                         <label htmlFor="description">Description</label>
                         <textarea name="description" placeholder="Description"></textarea>
                         <label htmlFor="campus">Campus Picture</label>
-                        <input type="file" name="campus" required/>
+                        <input type="file" name="campus" required />
                         <label htmlFor="logo">Logo</label>
-                        <input type="file" name="logo" required/>
-                        <input type="submit" value="Create" className="submitInput"/>
+                        <input type="file" name="logo" required />
+                        <input type="submit" value="Create" className="submitInput" />
                     </form>
                 </div>
             </div>
 
             <style jsx>{`
-                .container{
+                .container {
                     padding-top: 50px;
                     text-align: left;
                 }
 
-                @media screen and (min-width: 1000px){
-                    .bodyContent{
+                @media screen and (min-width: 1000px) {
+                    .bodyContent {
                         width: auto;
                         height: auto;
                         position: relative;
@@ -68,12 +70,12 @@ const Chapters: NextPage = () => {
                     }
                 }
 
-                h1{
+                h1 {
                     color: black;
                     padding: 0px 40px;
                 }
 
-                .formContainer{
+                .formContainer {
                     width: 100%;
                     height: auto;
                     position: relative;
@@ -82,7 +84,10 @@ const Chapters: NextPage = () => {
                     text-align: center;
                 }
 
-                input[type=text], input[type=file], select, textarea {
+                input[type="text"],
+                input[type="file"],
+                select,
+                textarea {
                     height: auto;
                     width: 100%;
                     padding: 10px 15px;
@@ -97,12 +102,12 @@ const Chapters: NextPage = () => {
                     font-family: inherit;
                 }
 
-                textarea{
+                textarea {
                     min-height: 150px;
                     resize: vertical;
                 }
 
-                label{
+                label {
                     display: block;
                     margin-bottom: 5px;
                     padding-left: 5px;
@@ -137,9 +142,8 @@ const Chapters: NextPage = () => {
                 body {
                     padding: 0;
                     margin: 0;
-                    font-family: -apple-system, BlinkMacSystemFont, Segoe UI,
-                        Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans,
-                        Helvetica Neue, sans-serif;
+                    font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell,
+                        Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
                 }
                 * {
                     box-sizing: border-box;
@@ -148,5 +152,33 @@ const Chapters: NextPage = () => {
         </div>
     );
 };
+
+export async function getServerSideProps(context: NextPageContext) {
+    const cookie = context.req?.headers.cookie;
+
+    //Since this is client side only absolute URLs are supported
+    //TODO: need to change url off of localhost in production
+    const resp = await fetch("http://localhost:3000/api/admin/validateLogin", {
+        headers: {
+            cookie: cookie!,
+        },
+    });
+
+    if (resp.status === 401 && !context.req) {
+        void Router.replace("/portal/login");
+        return { props: {} };
+    }
+
+    if (resp.status === 401 && context.req) {
+        context.res?.writeHead(302, {
+            //TODO: same here
+            Location: "http://localhost:3000/",
+        });
+        context.res?.end();
+        return { props: {} };
+    }
+
+    return { props: {} };
+}
 
 export default Chapters;

--- a/pages/portal/chapters/create.tsx
+++ b/pages/portal/chapters/create.tsx
@@ -2,7 +2,7 @@ import { NextPage, NextPageContext } from "next";
 import Head from "next/head";
 import { addChapter } from "requests/Chapter";
 import { Chapter } from "utils/types";
-
+import urls from "utils/urls";
 import Navigation from "components/Portal/Navigation";
 import Router from "next/router";
 import { FormEvent } from "react";
@@ -156,23 +156,20 @@ const Chapters: NextPage = () => {
 export async function getServerSideProps(context: NextPageContext) {
     const cookie = context.req?.headers.cookie;
 
-    //Since this is client side only absolute URLs are supported
-    //TODO: need to change url off of localhost in production
-    const resp = await fetch("http://localhost:3000/api/admin/validateLogin", {
+    const resp = await fetch(`${urls.baseUrl}${urls.api.admin.validateLogin}`, {
         headers: {
             cookie: cookie!,
         },
     });
 
     if (resp.status === 401 && !context.req) {
-        void Router.replace("/portal/login");
+        void Router.replace(`${urls.pages.portal.login}`);
         return { props: {} };
     }
 
     if (resp.status === 401 && context.req) {
         context.res?.writeHead(302, {
-            //TODO: same here
-            Location: "http://localhost:3000/",
+            Location: `${urls.baseUrl}`,
         });
         context.res?.end();
         return { props: {} };

--- a/pages/portal/chapters/index.tsx
+++ b/pages/portal/chapters/index.tsx
@@ -2,7 +2,7 @@ import { NextPage, NextPageContext } from "next";
 import Head from "next/head";
 import { getChapters } from "server/actions/Chapter";
 import { Chapter } from "utils/types";
-
+import urls from "utils/urls";
 import Navigation from "components/Portal/Navigation";
 import ChapterCard from "components/Portal/ChapterCard";
 import Router from "next/router";
@@ -122,23 +122,20 @@ const Chapters: NextPage<Props> = ({ chapter }) => {
 export async function getServerSideProps(context: NextPageContext) {
     const cookie = context.req?.headers.cookie;
 
-    //Since this is client side only absolute URLs are supported
-    //TODO: need to change url off of localhost in production
-    const resp = await fetch("http://localhost:3000/api/admin/validateLogin", {
+    const resp = await fetch(`${urls.baseUrl}${urls.api.admin.validateLogin}`, {
         headers: {
             cookie: cookie!,
         },
     });
 
     if (resp.status === 401 && !context.req) {
-        void Router.replace("/portal/login");
+        void Router.replace(`${urls.pages.portal.login}`);
         return { props: {} };
     }
 
     if (resp.status === 401 && context.req) {
         context.res?.writeHead(302, {
-            //TODO: same here
-            Location: "http://localhost:3000/",
+            Location: `${urls.baseUrl}`,
         });
         context.res?.end();
         return { props: {} };

--- a/pages/portal/chapters/index.tsx
+++ b/pages/portal/chapters/index.tsx
@@ -1,16 +1,17 @@
 import { NextPage, NextPageContext } from "next";
 import Head from "next/head";
-import { getChapters } from "requests/Chapter";
-import { Chapter } from 'utils/types';
+import { getChapters } from "server/actions/Chapter";
+import { Chapter } from "utils/types";
 
 import Navigation from "components/Portal/Navigation";
 import ChapterCard from "components/Portal/ChapterCard";
+import Router from "next/router";
 
 interface Props {
     chapter: Chapter[];
 }
 
-const Chapters: NextPage<Props> = ({chapter}) => {
+const Chapters: NextPage<Props> = ({ chapter }) => {
     return (
         <div className="container">
             <Head>
@@ -23,29 +24,29 @@ const Chapters: NextPage<Props> = ({chapter}) => {
             <div className="bodyContent">
                 <h1>Edit Chapters</h1>
                 <div className="newChapterBtnParent">
-                    <a href="chapters/create" className="newChapterBtn">New Chapter</a>
+                    <a href="chapters/create" className="newChapterBtn">
+                        New Chapter
+                    </a>
                 </div>
                 <div className="chaptersContainer">
-                    { //Display all of the chapters from the database
-                        chapter && (
-                        chapter.map(chap => {
-                            return(
-                                <ChapterCard chap={chap}/>
-                            )
-                        })
-                        )
+                    {
+                        //Display all of the chapters from the database
+                        chapter &&
+                            chapter.map((chap, i) => {
+                                return <ChapterCard key={i} chap={chap} />;
+                            })
                     }
                 </div>
             </div>
 
             <style jsx>{`
-                .container{
+                .container {
                     padding-top: 50px;
                     text-align: left;
                 }
 
-                @media screen and (min-width: 1000px){
-                    .bodyContent{
+                @media screen and (min-width: 1000px) {
+                    .bodyContent {
                         width: auto;
                         height: auto;
                         position: relative;
@@ -54,7 +55,7 @@ const Chapters: NextPage<Props> = ({chapter}) => {
                     }
                 }
 
-                h1{
+                h1 {
                     color: black;
                     padding: 0px 40px;
                 }
@@ -91,7 +92,7 @@ const Chapters: NextPage<Props> = ({chapter}) => {
                     background-color: #b59ccc;
                 }
 
-                .chaptersContainer{
+                .chaptersContainer {
                     width: 100%;
                     height: auto;
                     position: relative;
@@ -106,9 +107,8 @@ const Chapters: NextPage<Props> = ({chapter}) => {
                 body {
                     padding: 0;
                     margin: 0;
-                    font-family: -apple-system, BlinkMacSystemFont, Segoe UI,
-                        Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans,
-                        Helvetica Neue, sans-serif;
+                    font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell,
+                        Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
                 }
                 * {
                     box-sizing: border-box;
@@ -119,14 +119,37 @@ const Chapters: NextPage<Props> = ({chapter}) => {
 };
 
 //Get all of the chapters
-Chapters.getInitialProps = async ( context: NextPageContext ) => {
-    //Query to get all of the chapters
-    let chapterQuery: Chapter = new Object;
-    var chapters: Chapter[] = await getChapters(chapterQuery);
-    //Return an array of the chapters
-    return {
-        chapter: chapters,
+export async function getServerSideProps(context: NextPageContext) {
+    const cookie = context.req?.headers.cookie;
+
+    //Since this is client side only absolute URLs are supported
+    //TODO: need to change url off of localhost in production
+    const resp = await fetch("http://localhost:3000/api/admin/validateLogin", {
+        headers: {
+            cookie: cookie!,
+        },
+    });
+
+    if (resp.status === 401 && !context.req) {
+        void Router.replace("/portal/login");
+        return { props: {} };
     }
+
+    if (resp.status === 401 && context.req) {
+        context.res?.writeHead(302, {
+            //TODO: same here
+            Location: "http://localhost:3000/",
+        });
+        context.res?.end();
+        return { props: {} };
+    }
+
+    //Query to get all of the chapters
+    const chapterQuery: Chapter = new Object();
+    const chapters: Chapter[] = await getChapters(chapterQuery);
+
+    //Return an array of the chapters
+    return { props: { chapter: JSON.parse(JSON.stringify(chapters)) as Chapter[] } };
 }
 
 export default Chapters;

--- a/pages/portal/dashboard.tsx
+++ b/pages/portal/dashboard.tsx
@@ -106,8 +106,6 @@ const Dashboard: NextPage = () => {
 export async function getServerSideProps(context: NextPageContext) {
     const cookie = context.req?.headers.cookie;
 
-    //Since this is client side only absolute URLs are supported
-    //TODO: need to change url off of localhost in production
     const resp = await fetch(`${urls.baseUrl}${urls.api.admin.validateLogin}`, {
         headers: {
             cookie: cookie!,

--- a/pages/portal/dashboard.tsx
+++ b/pages/portal/dashboard.tsx
@@ -92,9 +92,8 @@ const Dashboard: NextPage = () => {
                 body {
                     padding: 0;
                     margin: 0;
-                    font-family: -apple-system, BlinkMacSystemFont, Segoe UI,
-                        Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans,
-                        Helvetica Neue, sans-serif;
+                    font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell,
+                        Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
                 }
                 * {
                     box-sizing: border-box;
@@ -104,34 +103,32 @@ const Dashboard: NextPage = () => {
     );
 };
 
-
-Dashboard.getInitialProps = async (context: NextPageContext) => {
-    const cookie = context.req?.headers.cookie
+export async function getServerSideProps(context: NextPageContext) {
+    const cookie = context.req?.headers.cookie;
 
     //Since this is client side only absolute URLs are supported
     //TODO: need to change url off of localhost in production
     const resp = await fetch("http://localhost:3000/api/admin/validateLogin", {
         headers: {
-            cookie: cookie!
-        }
-    })
+            cookie: cookie!,
+        },
+    });
 
-    if(resp.status === 401 && !context.req) {
-        Router.replace('/portal/login')
-        return {}
+    if (resp.status === 401 && !context.req) {
+        void Router.replace("/portal/login");
+        return { props: {} };
     }
 
-    if(resp.status === 401 && context.req)
-    {
+    if (resp.status === 401 && context.req) {
         context.res?.writeHead(302, {
             //TODO: same here
-            Location: "http://localhost:3000/"
-        })
-        context.res?.end()
-        return {}
+            Location: "http://localhost:3000/",
+        });
+        context.res?.end();
+        return { props: {} };
     }
 
-    return {}
+    return { props: {} };
 }
 
 export default Dashboard;

--- a/pages/portal/dashboard.tsx
+++ b/pages/portal/dashboard.tsx
@@ -119,7 +119,6 @@ export async function getServerSideProps(context: NextPageContext) {
 
     if (resp.status === 401 && context.req) {
         context.res?.writeHead(302, {
-            //TODO: same here
             Location: `${urls.baseUrl}`,
         });
         context.res?.end();

--- a/pages/portal/dashboard.tsx
+++ b/pages/portal/dashboard.tsx
@@ -25,7 +25,7 @@ const Dashboard: NextPage = () => {
                     <a className="dashChip" href="resources">
                         Edit Resources
                     </a>
-                    <a className="dashChip" href="journal">
+                    <a className="dashChip" href="journal/delete">
                         Update Journal
                     </a>
                 </div>

--- a/pages/portal/dashboard.tsx
+++ b/pages/portal/dashboard.tsx
@@ -108,21 +108,21 @@ export async function getServerSideProps(context: NextPageContext) {
 
     //Since this is client side only absolute URLs are supported
     //TODO: need to change url off of localhost in production
-    const resp = await fetch("http://localhost:3000/api/admin/validateLogin", {
+    const resp = await fetch(`${urls.baseUrl}${urls.api.admin.validateLogin}`, {
         headers: {
             cookie: cookie!,
         },
     });
 
     if (resp.status === 401 && !context.req) {
-        void Router.replace("/portal/login");
+        void Router.replace(`${urls.pages.portal.login}`);
         return { props: {} };
     }
 
     if (resp.status === 401 && context.req) {
         context.res?.writeHead(302, {
             //TODO: same here
-            Location: "http://localhost:3000/",
+            Location: `${urls.baseUrl}`,
         });
         context.res?.end();
         return { props: {} };

--- a/pages/portal/journal/delete.tsx
+++ b/pages/portal/journal/delete.tsx
@@ -1,27 +1,27 @@
-import { NextPage,  NextPageContext } from "next";
+import { NextPage, NextPageContext } from "next";
 import Head from "next/head";
 import Navigation from "components/Portal/Navigation";
 import urls from "utils/urls";
 import JournalEntryComponent from "components/Portal/JournalEntry";
-import {JournalEntry} from "utils/types";
-import {useState} from "react";
-interface Props{
-    entries: JournalEntry[],
+import { JournalEntry } from "utils/types";
+import { useState } from "react";
+import Router from "next/router";
+interface Props {
+    entries: JournalEntry[];
 }
 
-const AdminJournalDelete: NextPage<Props> = ({entries}) => {
+const AdminJournalDelete: NextPage<Props> = ({ entries }) => {
     const [isDeleting, setIsDeleting] = useState(false);
     const [responseStatus, setResponseStatus] = useState(0);
     const [warningDismissed, setWarningDismissed] = useState(false);
     const [deletingID, setDeletingID] = useState("");
-    const handleEntryApproval = async (e:React.SyntheticEvent) => {
+    const handleEntryApproval = async (e: React.SyntheticEvent) => {
         e.preventDefault();
         let response;
         const submitButton = e.target as HTMLButtonElement;
 
-
-        if(submitButton.name === "deleting"){
-            if(!isDeleting && warningDismissed){
+        if (submitButton.name === "deleting") {
+            if (!isDeleting && warningDismissed) {
                 response = await fetch(`/api/journal/deleteByID?id=${submitButton.value}`, {
                     method: "DELETE",
                 });
@@ -30,9 +30,8 @@ const AdminJournalDelete: NextPage<Props> = ({entries}) => {
                 setIsDeleting(true);
                 setDeletingID(submitButton.value);
             }
-
         }
-        if(submitButton.name === "delete"){
+        if (submitButton.name === "delete") {
             //Delete the entry
             setIsDeleting(false);
             response = await fetch(`/api/journal/deleteByID?id=${deletingID}`, {
@@ -41,12 +40,12 @@ const AdminJournalDelete: NextPage<Props> = ({entries}) => {
             setResponseStatus(response.status);
         }
     };
-    
-    const toggleWarningDismissed = (e:React.SyntheticEvent) => {
-        setWarningDismissed(true);
-    }
 
-    return(
+    const toggleWarningDismissed = (e: React.SyntheticEvent) => {
+        setWarningDismissed(true);
+    };
+
+    return (
         <main className="wrapper">
             <Head>
                 <title>Delete Journal Entries | Mindversity Website</title>
@@ -57,11 +56,26 @@ const AdminJournalDelete: NextPage<Props> = ({entries}) => {
                     <div className="modalBody">
                         <h1>Are you sure?</h1>
                         <p>Continuing with this action will delete the entry permanently.</p>
-                        <input type='checkbox' onClick={toggleWarningDismissed}/>
+                        <input type="checkbox" onClick={toggleWarningDismissed} />
                         <span>Do not show this message again.</span>
                         <div className="actionButtonContainer">
-                            <button type="submit" name="delete" className="actionButton actionButtonPrimary" onClick={handleEntryApproval}>Delete</button>
-                            <button className="actionButton actionButtonSecondary" onClick={() => {setIsDeleting(false); setDeletingID("")}}>Close</button>
+                            <button
+                                type="submit"
+                                name="delete"
+                                className="actionButton actionButtonPrimary"
+                                onClick={handleEntryApproval}
+                            >
+                                Delete
+                            </button>
+                            <button
+                                className="actionButton actionButtonSecondary"
+                                onClick={() => {
+                                    setIsDeleting(false);
+                                    setDeletingID("");
+                                }}
+                            >
+                                Close
+                            </button>
                         </div>
                     </div>
                 </div>
@@ -78,139 +92,141 @@ const AdminJournalDelete: NextPage<Props> = ({entries}) => {
                     </div>
                 )}
                 <h1 className="contentHeader">Posts to be deleted</h1>
-                {entries && (
+                {entries &&
                     entries.map(entry => {
                         return (
-                            <JournalEntryComponent key={entry.id} entry={entry} mode="delete" handleEntryApproval={handleEntryApproval}/>
-                        )
-                    })
-                )}
-
+                            <JournalEntryComponent
+                                key={entry.id}
+                                entry={entry}
+                                mode="delete"
+                                handleEntryApproval={handleEntryApproval}
+                            />
+                        );
+                    })}
             </form>
             <style jsx>{`
-                .actionButton{
+                .actionButton {
                     width: 230px;
                     height: 50px;
                     border-radius: 6px;
                     font-size: 1.2rem;
-                    border: 1px solid #8C69AA;
-                    cursor:pointer;
-                    transition:0.5s ease;
+                    border: 1px solid #8c69aa;
+                    cursor: pointer;
+                    transition: 0.5s ease;
                     align-self: flex-end;
                     margin: 10px;
                 }
                 .actionButtonPrimary {
-                    background: #8C69AA;
+                    background: #8c69aa;
                     color: white;
                 }
-                .actionButtonPrimary:hover{
-                    filter:brightness(1.2);
+                .actionButtonPrimary:hover {
+                    filter: brightness(1.2);
                 }
-                .actionButtonSecondary{
+                .actionButtonSecondary {
                     background: white;
-                    color: #8C69AA;
+                    color: #8c69aa;
                 }
-                .actionButtonSecondary:hover{
-                    filter:brightness(0.8);
+                .actionButtonSecondary:hover {
+                    filter: brightness(0.8);
                 }
-                .modalBody{
+                .modalBody {
                     background: white;
-                    width:500px;
-                    height:300px;
-                    padding:0.5rem;
-                    text-align:center;
-                    align-self:center;
+                    width: 500px;
+                    height: 300px;
+                    padding: 0.5rem;
+                    text-align: center;
+                    align-self: center;
                 }
-                .success{
+                .success {
                     background: #a8ff9e;
                     margin: 10px;
                     border: 1px solid #095400;
                     color: #095400;
-                    text-align:center;
+                    text-align: center;
                 }
-                .error{
+                .error {
                     background: #ff8a82;
                     margin: 10px;
                     color: #590601;
                     border: 1px solid #940900;
-                    text-align:center;
+                    text-align: center;
                 }
 
-
-                @media screen and (min-width: 1000px){
+                @media screen and (min-width: 1000px) {
                     .content {
                         margin-left: 430px;
                         margin-right: 60px;
-                        display:flex;
-                        flex-direction:column;
+                        display: flex;
+                        flex-direction: column;
                         height: 100vh;
-                    }   
-                    .rejectModal{
-                        width:100%;
-                        position:absolute;
-                        display:flex;
-                        flex-direction:column;
-                        justify-content:center;
-                        align-items:center;
-                        height:100%;
-                        background:rgba(0,0,0,0.2);
-                        z-index:2;
                     }
-                    .modalBody{
-                        margin-left:430px;
+                    .rejectModal {
+                        width: 100%;
+                        position: absolute;
+                        display: flex;
+                        flex-direction: column;
+                        justify-content: center;
+                        align-items: center;
+                        height: 100%;
+                        background: rgba(0, 0, 0, 0.2);
+                        z-index: 2;
+                    }
+                    .modalBody {
+                        margin-left: 430px;
                         margin-right: 60px;
                     }
-                    .rejectModal{
-                        width:100%;
-                        position:absolute;
-                        display:flex;
-                        flex-direction:column;
-                        justify-content:center;
-                        align-items:center;
-                        height:100%;
-                        background:rgba(0,0,0,0.2);
-                        z-index:2;
+                    .rejectModal {
+                        width: 100%;
+                        position: absolute;
+                        display: flex;
+                        flex-direction: column;
+                        justify-content: center;
+                        align-items: center;
+                        height: 100%;
+                        background: rgba(0, 0, 0, 0.2);
+                        z-index: 2;
                     }
-                    .modalBody{
-                        margin-left:430px;
+                    .modalBody {
+                        margin-left: 430px;
                         margin-right: 60px;
                     }
                 }
-                @media screen and (max-width: 999px){
+                @media screen and (max-width: 999px) {
                     .content {
                         margin-left: 30px;
-                        margin-right:30px;
-                        display:flex;
-                        flex-direction:column;
+                        margin-right: 30px;
+                        display: flex;
+                        flex-direction: column;
                         height: 100vh;
-                    }   
-                    .rejectModal{
-                        width:100%;
-                        position:absolute;
-                        display:flex;
-                        flex-direction:column;
-                        justify-content:center;
-                        align-items:center;
-                        height:100%;
-                        background:rgba(0,0,0,0.2);
-                        z-index:2;
                     }
-                    .contentHeader{
-                        text-align:center;
+                    .rejectModal {
+                        width: 100%;
+                        position: absolute;
+                        display: flex;
+                        flex-direction: column;
+                        justify-content: center;
+                        align-items: center;
+                        height: 100%;
+                        background: rgba(0, 0, 0, 0.2);
+                        z-index: 2;
                     }
-                    .rejectModal{
-                        width:100%;
-                        position:absolute;
-                        display:flex;
-                        flex-direction:column;
-                        justify-content:center;
-                        align-items:center;
-                        height:100%;
-                        background:rgba(0,0,0,0.2);
-                        z-index:2;
+                    .contentHeader {
+                        text-align: center;
                     }
-                    .contentHeader{
-                        text-align:center;
+                    .rejectModal {
+                        width: 100%;
+                        position: absolute;
+                        display: flex;
+                        flex-direction: column;
+                        justify-content: center;
+                        align-items: center;
+                        height: 100%;
+                        background: rgba(0, 0, 0, 0.2);
+                        z-index: 2;
+                    }
+                    .contentHeader {
+                        text-align: center;
                     }
                 }
             `}</style>
@@ -219,29 +235,51 @@ const AdminJournalDelete: NextPage<Props> = ({entries}) => {
                 body {
                     padding: 0;
                     margin: 0;
-                    font-family: -apple-system, BlinkMacSystemFont, Segoe UI,
-                        Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans,
-                        Helvetica Neue, sans-serif;
+                    font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell,
+                        Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
                 }
                 * {
                     box-sizing: border-box;
                 }
             `}</style>
         </main>
-    )
-}
-AdminJournalDelete.getInitialProps = async (context: NextPageContext) => {
-    //Load the journal entries that have already been reviewed.
-    const url:string = `${urls.baseUrl}/api/journal/getByReviewStatus?reviewed=true`;
+    );
+};
+
+export async function getServerSideProps(context: NextPageContext) {
+    const cookie = context.req?.headers.cookie;
+
+    //Since this is client side only absolute URLs are supported
+    //TODO: need to change url off of localhost in production
+    const resp = await fetch("http://localhost:3000/api/admin/validateLogin", {
+        headers: {
+            cookie: cookie!,
+        },
+    });
+
+    if (resp.status === 401 && !context.req) {
+        void Router.replace("/portal/login");
+        return { props: {} };
+    }
+
+    if (resp.status === 401 && context.req) {
+        context.res?.writeHead(302, {
+            //TODO: same here
+            Location: "http://localhost:3000/",
+        });
+        context.res?.end();
+        return { props: {} };
+    }
+
+    //Load the journal entries that haven't been reviewed.
+    const url = `${urls.baseUrl}/api/journal/getByReviewStatus?reviewed=true`;
     const response = await fetch(url, {
         method: "GET",
     });
-    let json = await response.json();
-    let entries: JournalEntry[] = json.payload
-    
-    return{
-        entries,
-    }
+    const json = (await response.json()) as { success: boolean; payload: JournalEntry[] };
+    const entries: JournalEntry[] = json.payload;
+
+    return { props: { entries: JSON.parse(JSON.stringify(entries)) as JournalEntry[] } };
 }
 
 export default AdminJournalDelete;

--- a/pages/portal/journal/delete.tsx
+++ b/pages/portal/journal/delete.tsx
@@ -249,23 +249,20 @@ const AdminJournalDelete: NextPage<Props> = ({ entries }) => {
 export async function getServerSideProps(context: NextPageContext) {
     const cookie = context.req?.headers.cookie;
 
-    //Since this is client side only absolute URLs are supported
-    //TODO: need to change url off of localhost in production
-    const resp = await fetch("http://localhost:3000/api/admin/validateLogin", {
+    const resp = await fetch(`${urls.baseUrl}${urls.api.admin.validateLogin}`, {
         headers: {
             cookie: cookie!,
         },
     });
 
     if (resp.status === 401 && !context.req) {
-        void Router.replace("/portal/login");
+        void Router.replace(`${urls.pages.portal.login}`);
         return { props: {} };
     }
 
     if (resp.status === 401 && context.req) {
         context.res?.writeHead(302, {
-            //TODO: same here
-            Location: "http://localhost:3000/",
+            Location: `${urls.baseUrl}`,
         });
         context.res?.end();
         return { props: {} };

--- a/pages/portal/journal/review.tsx
+++ b/pages/portal/journal/review.tsx
@@ -1,44 +1,41 @@
-import { NextPage,  NextPageContext } from "next";
+import { NextPage, NextPageContext } from "next";
 import Head from "next/head";
 import Navigation from "components/Portal/Navigation";
 import urls from "utils/urls";
 import JournalEntryComponent from "components/Portal/JournalEntry";
-import {JournalEntry} from "utils/types";
-import {useState} from "react";
-interface Props{
-    entries: JournalEntry[],
+import { JournalEntry } from "utils/types";
+import { useState } from "react";
+import Router from "next/router";
+interface Props {
+    entries: JournalEntry[];
 }
 
-const AdminJournalReview: NextPage<Props> = ({entries}) => {
+const AdminJournalReview: NextPage<Props> = ({ entries }) => {
     const [isRejecting, setIsRejecting] = useState(false); //Displays the warning modal
     const [warningDismissed, setWarningDismissed] = useState(false); //Used inside the warning modal to determine whether or not it should pop up again.
     const [currentRejectingID, setRejectingID] = useState(""); //The entry IDs are stored on the buttons of each entry, and since the modal is not attached to any particular entry, it has no way of getting an entry's ID. To get the entry ID, when the Reject button is initially clicked, the ID of that particular entry is stored here so it can be used within the modal.
     const [responseStatus, setResponseStatus] = useState(0); //Used to display a success/error message.
-    
 
-
-    const handleEntryApproval = async (e:React.SyntheticEvent) => {
+    const handleEntryApproval = async (e: React.SyntheticEvent) => {
         e.preventDefault();
         let response;
-        let submitButton = e.target as HTMLButtonElement;
-        if(submitButton.name === "approve"){
+        const submitButton = e.target as HTMLButtonElement;
+        if (submitButton.name === "approve") {
             //Approve the entry...
             response = await fetch(`/api/journal/review?approved=true&id=${submitButton.value}`, {
                 method: "PUT",
             });
             setResponseStatus(response.status);
-
         }
 
         //Button by the approve button
-        if(submitButton.name === "rejecting"){
+        if (submitButton.name === "rejecting") {
             //If the user has viewed the warning modal and selects the option to not view it again, then the next time they click the reject button, the entry will be rejected.
-            if(!isRejecting && warningDismissed){
+            if (!isRejecting && warningDismissed) {
                 response = await fetch(`/api/journal/review?approved=false&id=${submitButton.value}`, {
                     method: "PUT",
                 });
                 setResponseStatus(response.status);
-
             } else {
                 setIsRejecting(true);
                 setRejectingID(submitButton.value);
@@ -46,23 +43,21 @@ const AdminJournalReview: NextPage<Props> = ({entries}) => {
         }
 
         //This button is within the reject modal. If a user chooses to not dismiss the warning, then they can click the reject button within it to reject the entry.
-        if(submitButton.name === "reject"){
+        if (submitButton.name === "reject") {
             //Reject here...
             setIsRejecting(false);
             response = await fetch(`/api/journal/review?approved=false&id=${currentRejectingID}`, {
                 method: "PUT",
             });
             setResponseStatus(response.status);
-        } 
+        }
     };
 
-    const toggleWarningDismissed = (e:React.SyntheticEvent) => {
+    const toggleWarningDismissed = (e: React.SyntheticEvent) => {
         setWarningDismissed(true);
-    }
+    };
 
-
-
-    return(
+    return (
         <main className="wrapper">
             <Head>
                 <title>Review Journal Entries | Mindversity Website</title>
@@ -72,20 +67,34 @@ const AdminJournalReview: NextPage<Props> = ({entries}) => {
                     <div className="modalBody">
                         <h1>Are you sure?</h1>
                         <p>Continuing with this action will delete the entry permanently.</p>
-                        <input type='checkbox' onClick={toggleWarningDismissed}/>
+                        <input type="checkbox" onClick={toggleWarningDismissed} />
                         <span>Do not show this message again.</span>
                         <div className="actionButtonContainer">
-                            <button type="submit" name="reject" className="actionButton actionButtonPrimary" onClick={handleEntryApproval}>Reject</button>
-                            <button className="actionButton actionButtonSecondary" onClick={() => {setIsRejecting(false); setRejectingID("")}}>Close</button>
+                            <button
+                                type="submit"
+                                name="reject"
+                                className="actionButton actionButtonPrimary"
+                                onClick={handleEntryApproval}
+                            >
+                                Reject
+                            </button>
+                            <button
+                                className="actionButton actionButtonSecondary"
+                                onClick={() => {
+                                    setIsRejecting(false);
+                                    setRejectingID("");
+                                }}
+                            >
+                                Close
+                            </button>
                         </div>
                     </div>
                 </div>
             )}
 
-
             <Navigation />
 
-            <form className="content"> 
+            <form className="content">
                 {responseStatus === 200 && (
                     <div className="success">
                         <p>Entry action successful.</p>
@@ -97,111 +106,113 @@ const AdminJournalReview: NextPage<Props> = ({entries}) => {
                     </div>
                 )}
 
-
                 <h1 className="contentHeader">Posts to be reviewed</h1>
-                {entries && (
+                {entries &&
                     entries.map(entry => {
                         return (
-                            <JournalEntryComponent key={entry.id} entry={entry} handleEntryApproval={handleEntryApproval} mode="review"/>
-                        )
-                    })
-                )}
-
+                            <JournalEntryComponent
+                                key={entry.id}
+                                entry={entry}
+                                handleEntryApproval={handleEntryApproval}
+                                mode="review"
+                            />
+                        );
+                    })}
             </form>
             <style jsx>{`
-                .actionButton{
+                .actionButton {
                     width: 230px;
                     height: 50px;
                     border-radius: 6px;
                     font-size: 1.2rem;
-                    border: 1px solid #8C69AA;
-                    cursor:pointer;
-                    transition:0.5s ease;
+                    border: 1px solid #8c69aa;
+                    cursor: pointer;
+                    transition: 0.5s ease;
                     align-self: flex-end;
                     margin: 10px;
                 }
                 .actionButtonPrimary {
-                    background: #8C69AA;
+                    background: #8c69aa;
                     color: white;
                 }
-                .actionButtonPrimary:hover{
-                    filter:brightness(1.2);
+                .actionButtonPrimary:hover {
+                    filter: brightness(1.2);
                 }
-                .actionButtonSecondary{
+                .actionButtonSecondary {
                     background: white;
-                    color: #8C69AA;
+                    color: #8c69aa;
                 }
-                .actionButtonSecondary:hover{
-                    filter:brightness(0.8);
+                .actionButtonSecondary:hover {
+                    filter: brightness(0.8);
                 }
-                .modalBody{
+                .modalBody {
                     background: white;
-                    width:500px;
-                    height:300px;
-                    padding:0.5rem;
-                    text-align:center;
-                    align-self:center;
+                    width: 500px;
+                    height: 300px;
+                    padding: 0.5rem;
+                    text-align: center;
+                    align-self: center;
                 }
-                .success{
+                .success {
                     background: #a8ff9e;
                     margin: 10px;
                     border: 1px solid #095400;
                     color: #095400;
-                    text-align:center;
+                    text-align: center;
                 }
-                .error{
+                .error {
                     background: #ff8a82;
                     margin: 10px;
                     color: #590601;
                     border: 1px solid #940900;
-                    text-align:center;
+                    text-align: center;
                 }
-                @media screen and (min-width: 1000px){
+                @media screen and (min-width: 1000px) {
                     .content {
                         margin-left: 430px;
                         margin-right: 60px;
-                        display:flex;
-                        flex-direction:column;
+                        display: flex;
+                        flex-direction: column;
                         height: 100vh;
-                        position:relative;
+                        position: relative;
                     }
-                    .rejectModal{
-                        width:100%;
-                        position:absolute;
-                        display:flex;
-                        flex-direction:column;
-                        justify-content:center;
-                        align-items:center;
-                        height:100%;
-                        background:rgba(0,0,0,0.2);
-                        z-index:2;
+                    .rejectModal {
+                        width: 100%;
+                        position: absolute;
+                        display: flex;
+                        flex-direction: column;
+                        justify-content: center;
+                        align-items: center;
+                        height: 100%;
+                        background: rgba(0, 0, 0, 0.2);
+                        z-index: 2;
                     }
-                    .modalBody{
-                        margin-left:430px;
+                    .modalBody {
+                        margin-left: 430px;
                         margin-right: 60px;
                     }
                 }
-                @media screen and (max-width: 999px){
+                @media screen and (max-width: 999px) {
                     .content {
                         margin-left: 30px;
-                        margin-right:30px;
-                        display:flex;
-                        flex-direction:column;
+                        margin-right: 30px;
+                        display: flex;
+                        flex-direction: column;
                         height: 100vh;
                     }
-                    .rejectModal{
-                        width:100%;
-                        position:absolute;
-                        display:flex;
-                        flex-direction:column;
-                        justify-content:center;
-                        align-items:center;
-                        height:100%;
-                        background:rgba(0,0,0,0.2);
-                        z-index:2;
+                    .rejectModal {
+                        width: 100%;
+                        position: absolute;
+                        display: flex;
+                        flex-direction: column;
+                        justify-content: center;
+                        align-items: center;
+                        height: 100%;
+                        background: rgba(0, 0, 0, 0.2);
+                        z-index: 2;
                     }
-                    .contentHeader{
-                        text-align:center;
+                    .contentHeader {
+                        text-align: center;
                     }
                 }
             `}</style>
@@ -210,28 +221,51 @@ const AdminJournalReview: NextPage<Props> = ({entries}) => {
                 body {
                     padding: 0;
                     margin: 0;
-                    font-family: -apple-system, BlinkMacSystemFont, Segoe UI,
-                        Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans,
-                        Helvetica Neue, sans-serif;
+                    font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell,
+                        Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
                 }
                 * {
                     box-sizing: border-box;
                 }
             `}</style>
         </main>
-    )
-}
-AdminJournalReview.getInitialProps = async (context: NextPageContext) => {
+    );
+};
+
+export async function getServerSideProps(context: NextPageContext) {
+    const cookie = context.req?.headers.cookie;
+
+    //Since this is client side only absolute URLs are supported
+    //TODO: need to change url off of localhost in production
+    const resp = await fetch("http://localhost:3000/api/admin/validateLogin", {
+        headers: {
+            cookie: cookie!,
+        },
+    });
+
+    if (resp.status === 401 && !context.req) {
+        void Router.replace("/portal/login");
+        return { props: {} };
+    }
+
+    if (resp.status === 401 && context.req) {
+        context.res?.writeHead(302, {
+            //TODO: same here
+            Location: "http://localhost:3000/",
+        });
+        context.res?.end();
+        return { props: {} };
+    }
+
     //Load the journal entries that haven't been reviewed.
-    const url:string = `${urls.baseUrl as string}/api/journal/getByReviewStatus?reviewed=false`;
+    const url = `${urls.baseUrl}/api/journal/getByReviewStatus?reviewed=false`;
     const response = await fetch(url, {
         method: "GET",
     });
-    let json = await response.json();
-    let entries: JournalEntry[] = json.payload
-    return{
-        entries,
-    }
+    const json = (await response.json()) as { success: boolean; payload: JournalEntry[] };
+    const entries: JournalEntry[] = json.payload;
+
+    return { props: { entries: JSON.parse(JSON.stringify(entries)) as JournalEntry[] } };
 }
 
 export default AdminJournalReview;

--- a/pages/portal/journal/review.tsx
+++ b/pages/portal/journal/review.tsx
@@ -235,23 +235,20 @@ const AdminJournalReview: NextPage<Props> = ({ entries }) => {
 export async function getServerSideProps(context: NextPageContext) {
     const cookie = context.req?.headers.cookie;
 
-    //Since this is client side only absolute URLs are supported
-    //TODO: need to change url off of localhost in production
-    const resp = await fetch("http://localhost:3000/api/admin/validateLogin", {
+    const resp = await fetch(`${urls.baseUrl}${urls.api.admin.validateLogin}`, {
         headers: {
             cookie: cookie!,
         },
     });
 
     if (resp.status === 401 && !context.req) {
-        void Router.replace("/portal/login");
+        void Router.replace(`${urls.pages.portal.login}`);
         return { props: {} };
     }
 
     if (resp.status === 401 && context.req) {
         context.res?.writeHead(302, {
-            //TODO: same here
-            Location: "http://localhost:3000/",
+            Location: `${urls.baseUrl}`,
         });
         context.res?.end();
         return { props: {} };

--- a/pages/portal/resources/[id].tsx
+++ b/pages/portal/resources/[id].tsx
@@ -1,182 +1,219 @@
-import { NextPage, NextPageContext } from 'next'
+import { NextPage, NextPageContext } from "next";
 import Head from "next/head";
-import React, { useRef, FormEvent } from 'react'
-import { Resource } from 'utils/types'
+import React, { useRef, FormEvent } from "react";
+import { Resource } from "utils/types";
 import { getResources } from "requests/Resource";
 import Navigation from "components/Portal/Navigation";
-import Router from 'next/router';
-import urls from 'utils/urls'
+import Router from "next/router";
+import urls from "utils/urls";
 
 interface Props {
     resource: Resource;
 }
 
-
-const editResourcePage: NextPage<Props> = ({resource}) => {
-
-    const nameEle = useRef<HTMLInputElement>(null)
-    const cateEle = useRef<HTMLSelectElement>(null)
-    const linkEle = useRef<HTMLInputElement>(null)
+const EditResourcePage: NextPage<Props> = ({ resource }) => {
+    const nameEle = useRef<HTMLInputElement>(null);
+    const cateEle = useRef<HTMLSelectElement>(null);
+    const linkEle = useRef<HTMLInputElement>(null);
 
     const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
-        e.preventDefault()
+        e.preventDefault();
 
         const chagedResource: Resource = {
             _id: resource._id,
             name: nameEle.current?.value,
             category: cateEle.current?.value,
             link: linkEle.current?.value,
-        }
+        };
 
         const response = await fetch(`${urls.baseUrl}${urls.api.resource.update}`, {
-            method: 'POST',
+            method: "POST",
             headers: {
-                'Content-Type': 'application/json'
+                "Content-Type": "application/json",
             },
-            body: JSON.stringify(chagedResource)
-        })
+            body: JSON.stringify(chagedResource),
+        });
 
-        Router.push('/portal/resources')
-    }
-
+        void Router.push("/portal/resources");
+    };
 
     return (
         <div className="container">
+            <Head>
+                <title>MindVersity | Admin Portal</title>
+                <link rel="icon" href="/favicon.ico" />
+            </Head>
 
-        <Head>
-            <title>MindVersity | Admin Portal</title>
-            <link rel="icon" href="/favicon.ico" />
-        </Head>
+            <Navigation />
 
-        <Navigation />
-
-        <div className="bodyContent">
+            <div className="bodyContent">
                 <h1>Edit Resource</h1>
                 <div className="formContainer">
                     <form onSubmit={handleSubmit} method="post">
                         <label htmlFor="name">Resource Name</label>
-                        <input ref={nameEle} type="text" name="name" placeholder="Resource Name" defaultValue={resource.name} required/>
+                        <input
+                            ref={nameEle}
+                            type="text"
+                            name="name"
+                            placeholder="Resource Name"
+                            defaultValue={resource.name}
+                            required
+                        />
                         <label htmlFor="category">Category</label>
-                        <select ref={cateEle} name="category" id="categoryChoice" defaultValue={resource.category || "national"}>
+                        <select
+                            ref={cateEle}
+                            name="category"
+                            id="categoryChoice"
+                            defaultValue={resource.category || "national"}
+                        >
                             <option value="national">National</option>
                             <option value="mindversity">Mindversity</option>
                             <option value="help">Help</option>
                         </select>
                         <label htmlFor="linkornumber">Link or Phone Number</label>
-                        <input ref={linkEle} type="text" name="link" placeholder="Link or Phone Number" defaultValue={resource.link}/>
-                        <input type="submit" value="Update" className="submitInput"/>
+                        <input
+                            ref={linkEle}
+                            type="text"
+                            name="link"
+                            placeholder="Link or Phone Number"
+                            defaultValue={resource.link}
+                        />
+                        <input type="submit" value="Update" className="submitInput" />
                     </form>
                 </div>
             </div>
 
             <style jsx>{`
-            .container{
-                padding-top: 50px;
-                text-align: left;
-            }
+                .container {
+                    padding-top: 50px;
+                    text-align: left;
+                }
 
-            @media screen and (min-width: 1000px){
-                .bodyContent{
-                    width: auto;
+                @media screen and (min-width: 1000px) {
+                    .bodyContent {
+                        width: auto;
+                        height: auto;
+                        position: relative;
+                        display: body;
+                        margin-left: 375px;
+                    }
+                }
+
+                h1 {
+                    color: black;
+                    padding: 0px 40px;
+                }
+
+                .formContainer {
+                    width: 100%;
                     height: auto;
                     position: relative;
-                    display: body;
-                    margin-left: 375px;
+                    display: block;
+                    padding: 20px 40px;
+                    text-align: center;
                 }
-            }
 
-            h1{
-                color: black;
-                padding: 0px 40px;
-            }
+                input[type="text"],
+                select,
+                textarea {
+                    height: auto;
+                    width: 75%;
+                    padding: 10px 15px;
+                    position: relative;
+                    display: block;
+                    border: none;
+                    font-size: 16px;
+                    margin-bottom: 15px;
+                    outline: none;
+                    border-radius: 5px;
+                    background-color: #eae0f1;
+                    font-family: inherit;
+                }
 
-            .formContainer{
-                width: 100%;
-                height: auto;
-                position: relative;
-                display: block;
-                padding: 20px 40px;
-                text-align: center;
-            }
+                textarea {
+                    min-height: 150px;
+                    resize: vertical;
+                }
 
-            input[type=text], select, textarea {
-                height: auto;
-                width: 75%;
-                padding: 10px 15px;
-                position: relative;
-                display: block;
-                border: none;
-                font-size: 16px;
-                margin-bottom: 15px;
-                outline: none;
-                border-radius: 5px;
-                background-color: #eae0f1;
-                font-family: inherit;
-            }
+                label {
+                    display: block;
+                    margin-bottom: 5px;
+                    padding-left: 5px;
+                    text-align: left;
+                    font-size: 16px;
+                }
 
-            textarea{
-                min-height: 150px;
-                resize: vertical;
-            }
+                .submitInput {
+                    height: auto;
+                    width: auto;
+                    padding: 10px 40px;
+                    position: relative;
+                    display: block;
+                    border: none;
+                    font-size: 16px;
+                    margin-top: 40px;
+                    outline: none;
+                    border-radius: 6px;
+                    background-color: #8c69aa;
+                    color: white;
+                    transition: background 0.5s ease;
+                }
 
-            label{
-                display: block;
-                margin-bottom: 5px;
-                padding-left: 5px;
-                text-align: left;
-                font-size: 16px;
-            }
-
-            .submitInput {
-                height: auto;
-                width: auto;
-                padding: 10px 40px;
-                position: relative;
-                display: block;
-                border: none;
-                font-size: 16px;
-                margin-top: 40px;
-                outline: none;
-                border-radius: 6px;
-                background-color: #8c69aa;
-                color: white;
-                transition: background 0.5s ease;
-            }
-
-            .submitInput:hover {
-                cursor: pointer;
-                background-color: #b59ccc;
-            }
+                .submitInput:hover {
+                    cursor: pointer;
+                    background-color: #b59ccc;
+                }
             `}</style>
 
             <style jsx global>{`
-            html,
-            body {
-                padding: 0;
-                margin: 0;
-                font-family: -apple-system, BlinkMacSystemFont, Segoe UI,
-                    Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans,
-                    Helvetica Neue, sans-serif;
-            }
-            * {
-                box-sizing: border-box;
-            }
+                html,
+                body {
+                    padding: 0;
+                    margin: 0;
+                    font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell,
+                        Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+                }
+                * {
+                    box-sizing: border-box;
+                }
             `}</style>
         </div>
-    )
-}
+    );
+};
 
-editResourcePage.getInitialProps = async (context: NextPageContext) => {
-    let resourceQuery: Resource = {_id: context.query.id as string}
-    let resource: Resource[] = await getResources(resourceQuery)
+export async function getServerSideProps(context: NextPageContext) {
+    const cookie = context.req?.headers.cookie;
 
-    if(resource.length === 0) {
-        Router.replace('/portal/dashboard')
+    //Since this is client side only absolute URLs are supported
+    //TODO: need to change url off of localhost in production
+    const resp = await fetch("http://localhost:3000/api/admin/validateLogin", {
+        headers: {
+            cookie: cookie!,
+        },
+    });
+
+    if (resp.status === 401 && !context.req) {
+        void Router.replace("/portal/login");
+        return { props: {} };
     }
 
-    return {
-        resource: resource[0]
+    if (resp.status === 401 && context.req) {
+        context.res?.writeHead(302, {
+            //TODO: same here
+            Location: "http://localhost:3000/",
+        });
+        context.res?.end();
+        return { props: {} };
     }
+
+    const resourceQuery: Resource = { _id: context.query.id as string };
+    const resource: Resource[] = (await getResources(resourceQuery)) as Resource[];
+
+    if (resource.length === 0) {
+        void Router.replace("/portal/dashboard");
+    }
+
+    return { props: { resource: JSON.parse(JSON.stringify(resource[0])) as Resource[] } };
 }
 
-export default editResourcePage;
+export default EditResourcePage;

--- a/pages/portal/resources/[id].tsx
+++ b/pages/portal/resources/[id].tsx
@@ -184,23 +184,20 @@ const EditResourcePage: NextPage<Props> = ({ resource }) => {
 export async function getServerSideProps(context: NextPageContext) {
     const cookie = context.req?.headers.cookie;
 
-    //Since this is client side only absolute URLs are supported
-    //TODO: need to change url off of localhost in production
-    const resp = await fetch("http://localhost:3000/api/admin/validateLogin", {
+    const resp = await fetch(`${urls.baseUrl}${urls.api.admin.validateLogin}`, {
         headers: {
             cookie: cookie!,
         },
     });
 
     if (resp.status === 401 && !context.req) {
-        void Router.replace("/portal/login");
+        void Router.replace(`${urls.pages.portal.login}`);
         return { props: {} };
     }
 
     if (resp.status === 401 && context.req) {
         context.res?.writeHead(302, {
-            //TODO: same here
-            Location: "http://localhost:3000/",
+            Location: `${urls.baseUrl}`,
         });
         context.res?.end();
         return { props: {} };
@@ -210,7 +207,7 @@ export async function getServerSideProps(context: NextPageContext) {
     const resource: Resource[] = (await getResources(resourceQuery)) as Resource[];
 
     if (resource.length === 0) {
-        void Router.replace("/portal/dashboard");
+        void Router.replace(`${urls.pages.portal.dashboard}`);
     }
 
     return { props: { resource: JSON.parse(JSON.stringify(resource[0])) as Resource[] } };

--- a/pages/portal/resources/create.tsx
+++ b/pages/portal/resources/create.tsx
@@ -1,163 +1,188 @@
-import { NextPage } from 'next'
+import { NextPage, NextPageContext } from "next";
 import Head from "next/head";
-import React, { useRef, FormEvent } from 'react'
-import { Resource } from 'utils/types'
+import React, { useRef, FormEvent } from "react";
+import { Resource } from "utils/types";
 import Navigation from "components/Portal/Navigation";
-import Router from 'next/router';
-import urls from 'utils/urls'
-
+import Router from "next/router";
+import urls from "utils/urls";
 
 const CreateResourcePage: NextPage = () => {
-
-    const nameEle = useRef<HTMLInputElement>(null)
-    const cateEle = useRef<HTMLSelectElement>(null)
-    const linkEle = useRef<HTMLInputElement>(null)
+    const nameEle = useRef<HTMLInputElement>(null);
+    const cateEle = useRef<HTMLSelectElement>(null);
+    const linkEle = useRef<HTMLInputElement>(null);
 
     const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
-        e.preventDefault()
+        e.preventDefault();
 
         const newResource: Resource = {
             name: nameEle.current?.value,
             category: cateEle.current?.value,
             link: linkEle.current?.value,
-        }
+        };
 
-        const response = await fetch(`${urls.baseUrl as string}${urls.api.resource.add as string}`, {
-            method: 'POST',
+        const response = await fetch(`${urls.baseUrl}${urls.api.resource.add}`, {
+            method: "POST",
             headers: {
-                'Content-Type': 'application/json'
+                "Content-Type": "application/json",
             },
-            body: JSON.stringify(newResource)
-        })
+            body: JSON.stringify(newResource),
+        });
 
-        Router.push('/portal/resources')
-    }
-
+        void Router.push("/portal/resources");
+    };
 
     return (
         <div className="container">
+            <Head>
+                <title>MindVersity | Admin Portal</title>
+                <link rel="icon" href="/favicon.ico" />
+            </Head>
 
-        <Head>
-            <title>MindVersity | Admin Portal</title>
-            <link rel="icon" href="/favicon.ico" />
-        </Head>
+            <Navigation />
 
-        <Navigation />
-
-        <div className="bodyContent">
+            <div className="bodyContent">
                 <h1>Create Resource</h1>
                 <div className="formContainer">
                     <form onSubmit={handleSubmit} method="post">
                         <label htmlFor="name">Resource Name</label>
-                        <input ref={nameEle} type="text" name="name" placeholder="Resource Name"  required/>
+                        <input ref={nameEle} type="text" name="name" placeholder="Resource Name" required />
                         <label htmlFor="category">Category</label>
-                        <select ref={cateEle} name="category" id="categoryChoice" >
+                        <select ref={cateEle} name="category" id="categoryChoice">
                             <option value="national">National</option>
                             <option value="mindversity">Mindversity</option>
                             <option value="help">Help</option>
                         </select>
                         <label htmlFor="linkornumber">Link or Phone Number</label>
                         <input ref={linkEle} type="text" name="link" placeholder="Link or Phone Number" />
-                        <input type="submit" value="Create" className="submitInput"/>
+                        <input type="submit" value="Create" className="submitInput" />
                     </form>
                 </div>
             </div>
 
             <style jsx>{`
-            .container{
-                padding-top: 50px;
-                text-align: left;
-            }
+                .container {
+                    padding-top: 50px;
+                    text-align: left;
+                }
 
-            @media screen and (min-width: 1000px){
-                .bodyContent{
-                    width: auto;
+                @media screen and (min-width: 1000px) {
+                    .bodyContent {
+                        width: auto;
+                        height: auto;
+                        position: relative;
+                        display: body;
+                        margin-left: 375px;
+                    }
+                }
+
+                h1 {
+                    color: black;
+                    padding: 0px 40px;
+                }
+
+                .formContainer {
+                    width: 100%;
                     height: auto;
                     position: relative;
-                    display: body;
-                    margin-left: 375px;
+                    display: block;
+                    padding: 20px 40px;
+                    text-align: center;
                 }
-            }
 
-            h1{
-                color: black;
-                padding: 0px 40px;
-            }
+                input[type="text"],
+                select,
+                textarea {
+                    height: auto;
+                    width: 75%;
+                    padding: 10px 15px;
+                    position: relative;
+                    display: block;
+                    border: none;
+                    font-size: 16px;
+                    margin-bottom: 15px;
+                    outline: none;
+                    border-radius: 5px;
+                    background-color: #eae0f1;
+                    font-family: inherit;
+                }
 
-            .formContainer{
-                width: 100%;
-                height: auto;
-                position: relative;
-                display: block;
-                padding: 20px 40px;
-                text-align: center;
-            }
+                textarea {
+                    min-height: 150px;
+                    resize: vertical;
+                }
 
-            input[type=text], select, textarea {
-                height: auto;
-                width: 75%;
-                padding: 10px 15px;
-                position: relative;
-                display: block;
-                border: none;
-                font-size: 16px;
-                margin-bottom: 15px;
-                outline: none;
-                border-radius: 5px;
-                background-color: #eae0f1;
-                font-family: inherit;
-            }
+                label {
+                    display: block;
+                    margin-bottom: 5px;
+                    padding-left: 5px;
+                    text-align: left;
+                    font-size: 16px;
+                }
 
-            textarea{
-                min-height: 150px;
-                resize: vertical;
-            }
+                .submitInput {
+                    height: auto;
+                    width: auto;
+                    padding: 10px 40px;
+                    position: relative;
+                    display: block;
+                    border: none;
+                    font-size: 16px;
+                    margin-top: 40px;
+                    outline: none;
+                    border-radius: 6px;
+                    background-color: #8c69aa;
+                    color: white;
+                    transition: background 0.5s ease;
+                }
 
-            label{
-                display: block;
-                margin-bottom: 5px;
-                padding-left: 5px;
-                text-align: left;
-                font-size: 16px;
-            }
-
-            .submitInput {
-                height: auto;
-                width: auto;
-                padding: 10px 40px;
-                position: relative;
-                display: block;
-                border: none;
-                font-size: 16px;
-                margin-top: 40px;
-                outline: none;
-                border-radius: 6px;
-                background-color: #8c69aa;
-                color: white;
-                transition: background 0.5s ease;
-            }
-
-            .submitInput:hover {
-                cursor: pointer;
-                background-color: #b59ccc;
-            }
+                .submitInput:hover {
+                    cursor: pointer;
+                    background-color: #b59ccc;
+                }
             `}</style>
 
             <style jsx global>{`
-            html,
-            body {
-                padding: 0;
-                margin: 0;
-                font-family: -apple-system, BlinkMacSystemFont, Segoe UI,
-                    Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans,
-                    Helvetica Neue, sans-serif;
-            }
-            * {
-                box-sizing: border-box;
-            }
+                html,
+                body {
+                    padding: 0;
+                    margin: 0;
+                    font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell,
+                        Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+                }
+                * {
+                    box-sizing: border-box;
+                }
             `}</style>
         </div>
-    )
+    );
+};
+
+export async function getServerSideProps(context: NextPageContext) {
+    const cookie = context.req?.headers.cookie;
+
+    //Since this is client side only absolute URLs are supported
+    //TODO: need to change url off of localhost in production
+    const resp = await fetch("http://localhost:3000/api/admin/validateLogin", {
+        headers: {
+            cookie: cookie!,
+        },
+    });
+
+    if (resp.status === 401 && !context.req) {
+        void Router.replace("/portal/login");
+        return { props: {} };
+    }
+
+    if (resp.status === 401 && context.req) {
+        context.res?.writeHead(302, {
+            //TODO: same here
+            Location: "http://localhost:3000/",
+        });
+        context.res?.end();
+        return { props: {} };
+    }
+
+    return { props: {} };
 }
 
 export default CreateResourcePage;

--- a/pages/portal/resources/create.tsx
+++ b/pages/portal/resources/create.tsx
@@ -160,23 +160,20 @@ const CreateResourcePage: NextPage = () => {
 export async function getServerSideProps(context: NextPageContext) {
     const cookie = context.req?.headers.cookie;
 
-    //Since this is client side only absolute URLs are supported
-    //TODO: need to change url off of localhost in production
-    const resp = await fetch("http://localhost:3000/api/admin/validateLogin", {
+    const resp = await fetch(`${urls.baseUrl}${urls.api.admin.validateLogin}`, {
         headers: {
             cookie: cookie!,
         },
     });
 
     if (resp.status === 401 && !context.req) {
-        void Router.replace("/portal/login");
+        void Router.replace(`${urls.pages.portal.login}`);
         return { props: {} };
     }
 
     if (resp.status === 401 && context.req) {
         context.res?.writeHead(302, {
-            //TODO: same here
-            Location: "http://localhost:3000/",
+            Location: `${urls.baseUrl}`,
         });
         context.res?.end();
         return { props: {} };

--- a/pages/portal/resources/index.tsx
+++ b/pages/portal/resources/index.tsx
@@ -139,23 +139,20 @@ const Resources: NextPage<Props> = ({ resource }) => {
 export async function getServerSideProps(context: NextPageContext) {
     const cookie = context.req?.headers.cookie;
 
-    //Since this is client side only absolute URLs are supported
-    //TODO: need to change url off of localhost in production
-    const resp = await fetch("http://localhost:3000/api/admin/validateLogin", {
+    const resp = await fetch(`${urls.baseUrl}${urls.api.admin.validateLogin}`, {
         headers: {
             cookie: cookie!,
         },
     });
 
     if (resp.status === 401 && !context.req) {
-        void Router.replace("/portal/login");
+        void Router.replace(`${urls.pages.portal.login}`);
         return { props: {} };
     }
 
     if (resp.status === 401 && context.req) {
         context.res?.writeHead(302, {
-            //TODO: same here
-            Location: "http://localhost:3000/",
+            Location: `${urls.baseUrl}`,
         });
         context.res?.end();
         return { props: {} };

--- a/pages/portal/resources/index.tsx
+++ b/pages/portal/resources/index.tsx
@@ -1,37 +1,37 @@
 import { NextPage, NextPageContext } from "next";
 import Head from "next/head";
-import { getResources } from "requests/Resource";
-import { Resource } from 'utils/types';
+import { getResources } from "server/actions/Resource";
+import { Resource } from "utils/types";
 import { ObjectID } from "mongodb";
 import Navigation from "components/Portal/Navigation";
 import ResourceCardComp from "components/Portal/ResourceCard";
 import { useState } from "react";
 import urls from "utils/urls";
+import Router from "next/router";
 
 interface Props {
     resource: Resource[];
 }
 
-const Resources: NextPage<Props> = ({resource}) => {
+const Resources: NextPage<Props> = ({ resource }) => {
+    const [resourcesList, setResourceList] = useState(resource);
 
-    let [resourcesList, setResourceList] = useState(resource)
+    const handleDelete = async (id: ObjectID | undefined) => {
+        if (id === undefined) return;
 
-    let handleDelete = async (id: ObjectID|undefined) => {
-        if(id === undefined) return
-        
         const response = await fetch(`${urls.baseUrl}${urls.api.resource.delete}`, {
-            method: 'POST',
+            method: "POST",
             headers: {
-                'Content-Type': 'application/json'
+                "Content-Type": "application/json",
             },
             body: JSON.stringify({
-                _id: id
-            })
-        })
+                _id: id,
+            }),
+        });
 
-        const newResourceList = resourcesList.filter(resourceItem => resourceItem._id !== id)
-        setResourceList(newResourceList)
-    }
+        const newResourceList = resourcesList.filter(resourceItem => resourceItem._id !== id);
+        setResourceList(newResourceList);
+    };
 
     return (
         <div className="container">
@@ -45,30 +45,26 @@ const Resources: NextPage<Props> = ({resource}) => {
             <div className="bodyContent">
                 <h1>Edit Resources</h1>
                 <div className="newResourceBtnParent">
-                    <a href="resources/create" className="newResourceBtn">New Resource</a>
+                    <a href="resources/create" className="newResourceBtn">
+                        New Resource
+                    </a>
                 </div>
                 <div className="resourcesContainer">
-                    {
-                        resourcesList && (
-                            resourcesList.map((reso, i) => {
-                                return (
-                                    <ResourceCardComp key={i} reso={reso} onDelete={handleDelete}/>
-                                )
-                            })
-                        )
-                    }
+                    {resourcesList &&
+                        resourcesList.map((reso, i) => {
+                            return <ResourceCardComp key={i} reso={reso} onDelete={handleDelete} />;
+                        })}
                 </div>
-                
             </div>
 
             <style jsx>{`
-                .container{
+                .container {
                     padding-top: 50px;
                     text-align: left;
                 }
 
-                @media screen and (min-width: 1000px){
-                    .bodyContent{
+                @media screen and (min-width: 1000px) {
+                    .bodyContent {
                         width: auto;
                         height: auto;
                         position: relative;
@@ -77,7 +73,7 @@ const Resources: NextPage<Props> = ({resource}) => {
                     }
                 }
 
-                h1{
+                h1 {
                     color: black;
                     padding: 0px 40px;
                 }
@@ -114,7 +110,7 @@ const Resources: NextPage<Props> = ({resource}) => {
                     background-color: #b59ccc;
                 }
 
-                .resourcesContainer{
+                .resourcesContainer {
                     width: 100%;
                     height: auto;
                     position: relative;
@@ -129,9 +125,8 @@ const Resources: NextPage<Props> = ({resource}) => {
                 body {
                     padding: 0;
                     margin: 0;
-                    font-family: -apple-system, BlinkMacSystemFont, Segoe UI,
-                        Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans,
-                        Helvetica Neue, sans-serif;
+                    font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell,
+                        Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
                 }
                 * {
                     box-sizing: border-box;
@@ -141,12 +136,36 @@ const Resources: NextPage<Props> = ({resource}) => {
     );
 };
 
-Resources.getInitialProps = async ( context: NextPageContext ) => {
-    let resources: Resource[] = await getResources({})
-    //Return an array of the chapters
-    return {
-        resource: resources
+export async function getServerSideProps(context: NextPageContext) {
+    const cookie = context.req?.headers.cookie;
+
+    //Since this is client side only absolute URLs are supported
+    //TODO: need to change url off of localhost in production
+    const resp = await fetch("http://localhost:3000/api/admin/validateLogin", {
+        headers: {
+            cookie: cookie!,
+        },
+    });
+
+    if (resp.status === 401 && !context.req) {
+        void Router.replace("/portal/login");
+        return { props: {} };
     }
+
+    if (resp.status === 401 && context.req) {
+        context.res?.writeHead(302, {
+            //TODO: same here
+            Location: "http://localhost:3000/",
+        });
+        context.res?.end();
+        return { props: {} };
+    }
+
+    const resources: Resource[] = await getResources({});
+
+    console.log(resources);
+
+    return { props: { resource: JSON.parse(JSON.stringify(resources)) as Resource[] } };
 }
 
 export default Resources;

--- a/server/actions/User.ts
+++ b/server/actions/User.ts
@@ -15,14 +15,12 @@ import { createTransport } from "nodemailer";
  * @throws Invalid Username or Password: if no credentials match
  */
 export async function login(user: User): Promise<string> {
-    if (user.email == null || user.password == null)
-        throw new Error("Parameters cannot be empty");
+    if (user.email == null || user.password == null) throw new Error("Parameters cannot be empty");
 
     await mongoDB();
 
     const apparentUser = await UserModel.findOne({ email: user.email });
-    if (!apparentUser || !apparentUser.password)
-        throw new Error("Invalid Username or Password");
+    if (!apparentUser || !apparentUser.password) throw new Error("Invalid Username or Password");
 
     const same = await compare(user.password, apparentUser.password);
     if (!same) throw new Error("Invalid Username or Password");
@@ -47,12 +45,10 @@ export async function login(user: User): Promise<string> {
  * @param user The user to be created and added to the database
  */
 export async function createUser(user: User): Promise<void> {
-    if (user.email == null || user.password == null) 
-        throw new Error("Parameters cannot be empty");
+    if (user.email == null || user.password == null) throw new Error("Parameters cannot be empty");
 
     const isNew = await checkEmail(user.email);
-    if (isNew?._id) 
-        throw new Error("Email already used");
+    if (isNew?._id) throw new Error("Email already used");
 
     await mongoDB();
 
@@ -89,12 +85,10 @@ export async function resetPassword(email: string, resetKey: string, newPassword
     await mongoDB();
 
     const userToReset = await UserModel.findOne({ email: email });
-    if (!userToReset || !userToReset.resetKey) 
-        throw new Error("Invalid User");
+    if (!userToReset || !userToReset.resetKey) throw new Error("Invalid User");
 
     const same = await compare(resetKey, userToReset.resetKey);
-    if (!same) 
-        throw new Error("Invalid User");
+    if (!same) throw new Error("Invalid User");
 
     const hashedPassword = await hash(newPassword, 10);
     userToReset.password = hashedPassword;
@@ -112,8 +106,7 @@ export async function sendForgotPasswordEmail(email: string): Promise<void> {
     await mongoDB();
 
     const existingUser = await checkEmail(email);
-    if (!existingUser) 
-        throw new Error("No user with that email found");
+    if (!existingUser) throw new Error("No user with that email found");
 
     const randomHash = randomBytes(16).toString("hex");
     const doubleHash = await hash(randomHash, 10);
@@ -133,8 +126,8 @@ export async function sendForgotPasswordEmail(email: string): Promise<void> {
         from: "mvpassreset@gmail.com",
         to: email,
         subject: "MindVersity Admin Password Reset",
-        text: `Click this link to reset your MindVeristy Admin password:\n${baseURL}/${urls.pages.newPassword}?email=${email}&key=${randomHash}`,
+        text: `Click this link to reset your MindVeristy Admin password:\n${baseURL}/${urls.pages.portal.newPassword}?email=${email}&key=${randomHash}`,
     };
 
-    transporter.sendMail(mailOptions);
+    void transporter.sendMail(mailOptions);
 }

--- a/utils/urls.ts
+++ b/utils/urls.ts
@@ -5,11 +5,15 @@ export default {
     dbUrl: process.env.MONGO_DB ?? "mongodb://localhost:27017",
     pages: {
         index: "/",
-        passwordReset: "portal/password-reset",
-        newPassword: "portal/new-password",
         journal: {
             index: "/journal",
             create: "/journal/create",
+        },
+        portal: {
+            login: "/portal",
+            dashboard: "/portal/dashboard",
+            passwordReset: "portal/password-reset",
+            newPassword: "portal/new-password",
         },
     },
     api: {

--- a/utils/urls.ts
+++ b/utils/urls.ts
@@ -1,12 +1,16 @@
 const prod = process.env.NODE_ENV === "production";
 
 export default {
-    baseUrl: prod ? process.env.PROD_URL : "http://localhost:3000",
+    baseUrl: prod ? (process.env.PROD_URL as string) : "http://localhost:3000",
     dbUrl: process.env.MONGO_DB ?? "mongodb://localhost:27017",
     pages: {
         index: "/",
         passwordReset: "portal/password-reset",
         newPassword: "portal/new-password",
+        journal: {
+            index: "/journal",
+            create: "/journal/create",
+        },
     },
     api: {
         admin: {

--- a/utils/urls.ts
+++ b/utils/urls.ts
@@ -19,6 +19,7 @@ export default {
             forgotPass: "/api/admin/forgotPass",
             resetPass: "/api/admin/resetPass",
             validateLogin: "/api/admin/validateLogin",
+            signout: "/api/admin/signout",
         },
         blog: {
             get: "/api/blog/getBlog",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7920,10 +7920,10 @@ typescript-service@^2.0.0:
   dependencies:
     tslib "^1.9.3"
 
-typescript@^3.9.3:
-  version "3.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.3.tgz#d3ac8883a97c26139e42df5e93eeece33d610b8a"
-  integrity sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==
+typescript@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
 uncontrollable@^7.0.0:
   version "7.1.1"


### PR DESCRIPTION
Changes
---
- Added `getServerSideProps` to all admin pages to check if the user is logged in otherwise it redirects
- Ran Linter all of those pages and fixed any errors that displayed
- Added a sign out button to navigation in the admin page and signout API route that just removes the auth cookie
- If a user is already logged in and clicks login, they are sent straight to the dashboard

Added APIs
---
- `/api/admin/signout`: Logs the caller out (removes auth cookie)

Minor Changes/Fixes
---
- Tried to remove string literal `http://localhost` from admin pages
- Updated TypeScript version which fixed an issue with the GeoLocation type on HomeChapters component
- `yarn build` now run successfully
- Allowed linter to run on all files changed in this PR to apply formatting