### PR TITLE
Create Journal Entry Button on Journals Page

### DIFF
--- a/components/CreateJournalEntry/create.module.scss
+++ b/components/CreateJournalEntry/create.module.scss
@@ -16,6 +16,7 @@ $dark-purple: #503E8C;
     text-decoration: none;
     display: flex;
     flex-direction: row;
+    align-items: center;
     transition: 0.3s ease;
     margin-bottom:10px;
     cursor: pointer;

--- a/pages/journal/create.tsx
+++ b/pages/journal/create.tsx
@@ -10,7 +10,29 @@ const Create: NextPage = () => {
             <Header/>
             <CreateJournalEntry/>
             <Footer/>
+            <style jsx global>{`
+            
+                html,
+                body {
+                    padding: 0;
+                    margin: 0;
+                    font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
+                    Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue,
+                    sans-serif;
+                }
+                
+                * {
+                    box-sizing: border-box;
+                }
+            
+            
+            
+        `}
+        
+
+            </style>
         </main>
+
     );
 
 }

--- a/pages/journal/index.tsx
+++ b/pages/journal/index.tsx
@@ -214,8 +214,9 @@ const JournalPage: NextPage<Props> = ({journalEntries}) => {
           flex-direction:column;
           justify-content:center;
           background:#8C69AA;
-          padding:0.5rem;
-          border-radius: 10px;
+          padding: 10px 20px 10px 20px;
+          text-align:center;
+          border-radius: 15px;
           font-weight:bold;
           color:white;
           cursor:pointer;

--- a/pages/journal/index.tsx
+++ b/pages/journal/index.tsx
@@ -1,6 +1,6 @@
 import { NextPage, NextPageContext, GetStaticPropsContext } from "next";
 import { useRouter } from "next/router";
-
+import Link from "next/link";
 import Head from "next/head";
 import Header from "components/Header";
 import SelectBtn from "components/Journal/SelectBtn";
@@ -55,6 +55,9 @@ const JournalPage: NextPage<Props> = ({journalEntries}) => {
       </div>
 
       <div className="btnRow">
+        <Link href='/journal/create'>
+          <span className="createBtn">Create a New Journal Entry</span>
+        </Link>
         <SelectBtn />
       </div>
 
@@ -203,6 +206,36 @@ const JournalPage: NextPage<Props> = ({journalEntries}) => {
         a.active:hover {
           text-decoration: none;
         }
+        
+        .createBtn{
+          margin-right: auto;
+          text-align:center;
+          display:flex;
+          flex-direction:column;
+          justify-content:center;
+          background:#8C69AA;
+          padding:0.5rem;
+          border-radius: 10px;
+          font-weight:bold;
+          color:white;
+          cursor:pointer;
+          transition: 0.3s ease;
+        }
+        .createBtn:hover{
+          filter:brightness(1.2);
+          transform:translateY(-2px);
+        }
+
+        @media only screen and (max-width:999px){
+          .btnRow{
+            display:flex;
+            flex-direction:column;
+            align-items:center;
+          }
+          .createBtn{
+            margin:10px;
+          }
+        }
 
         @media only screen and (min-width: 1200px) {
           .thumbnailContainer {
@@ -215,7 +248,7 @@ const JournalPage: NextPage<Props> = ({journalEntries}) => {
 };
 
 export async function getServerSideProps(context: NextPageContext) {
-  var data = await getJournalEntryByType(context.query.category as string);
+  let data = await getJournalEntryByType(context.query.category as string);
   return {
     props: {
       journalEntries: data,

--- a/pages/portal/dashboard.tsx
+++ b/pages/portal/dashboard.tsx
@@ -18,7 +18,7 @@ const Dashboard: NextPage = () => {
                 <h1>Welcome to MindVersity</h1>
 
                 <div className="dashChipParent">
-                    <h2>What yould you like to do?</h2>
+                    <h2>What would you like to do?</h2>
                     <a className="dashChip" href="chapters">
                         Manage Chapters
                     </a>


### PR DESCRIPTION
This PR adds in a button to the `/journals` route that will take users to `/journal/create`. 
### Screenshots ###
Desktop View
![Screenshot 2020-12-21 092329](https://user-images.githubusercontent.com/25257772/102793078-fd4bd100-436e-11eb-85bf-ad160e8205da.png)
Mobile View
![Screenshot 2020-12-21 092357](https://user-images.githubusercontent.com/25257772/102793120-0d63b080-436f-11eb-990c-4acd9bc711f1.png)

Please let me know if I need to change anything.

