### PR TITLE
Some journal changes

### DIFF
--- a/components/CreateJournalEntry/index.tsx
+++ b/components/CreateJournalEntry/index.tsx
@@ -6,6 +6,7 @@ import { BiImageAdd } from "react-icons/bi";
 import dynamic from "next/dynamic";
 const ReactQuill = dynamic(import("react-quill"), { ssr: false });
 import { Delta, Sources } from "quill";
+import urls from "utils/urls";
 
 interface IFormValues {
     title?: string | undefined;
@@ -20,17 +21,20 @@ interface IFormValues {
 const CreateJournalEntry: React.FC = () => {
     const [values, setValues] = useState({} as IFormValues); //Used to store the various values that will be sent to the backend.
     const [imageURL, setImageURL] = useState("");
+    const [fileTooLarge, setFileTooLarge] = useState(false);
 
     //Idea from: https://upmostly.com/tutorials/form-validation-using-custom-react-hooks
     const handleData = (e: React.SyntheticEvent) => {
         e.persist();
         const target = e.target as HTMLInputElement;
-        if (target != null) {
-            if (target.name == "image" && target.files != null) {
-                setValues(values => ({
-                    ...values,
-                    [target.name]: target.files?.item(0),
-                }));
+        if(target != null) {
+            if(target.name == "image" && target.files != null) {
+                if (target.files[0].size >= urls.CONTENTFUL_IMAGE_LIMIT) {
+                    setFileTooLarge(true);      
+                    setTimeout(() => {setFileTooLarge(false)}, 2000);
+                    return;
+                }
+                setValues(values => ({...values, [target.name]: target.files?.item(0)}));
                 handleImageURL(target.files[0]);
             } else {
                 setValues(values => ({
@@ -115,13 +119,14 @@ const CreateJournalEntry: React.FC = () => {
                         <div className={styles["icon-container"]}>
                             <BiImageAdd className={styles["image-icon"]} />
                         </div>
-                        <input
-                            type="file"
-                            name="image"
-                            className={styles["image-select"]}
-                            onChange={handleData}
-                            required
-                        />
+                        <input type="file" name="image" className={styles['image-select']} onChange={handleData} required/>
+                        {/* <div className={`alert alert-success ${this.state.showingAlert ? 'alert-shown' : 'alert-hidden'}`}> */}
+                        <div>
+                            <a className={styles['icon-container']}> 
+                                <strong>Error!</strong> 
+                                File size is too large, it must be below 20MB.
+                            </a>
+                        </div>
                     </div>
                     <div className={styles["text-container"]}>
                         <label htmlFor="title">Title</label>

--- a/components/CreateJournalEntry/index.tsx
+++ b/components/CreateJournalEntry/index.tsx
@@ -7,6 +7,11 @@ import dynamic from "next/dynamic";
 const ReactQuill = dynamic(import("react-quill"), { ssr: false });
 import { Delta, Sources } from "quill";
 import urls from "utils/urls";
+<<<<<<< HEAD
+=======
+import errors from "utils/errors";
+const ReactQuill = dynamic(import('react-quill'), { ssr: false});
+>>>>>>> File size checks and modified 404
 
 interface IFormValues {
     title?: string | undefined;
@@ -30,9 +35,19 @@ const CreateJournalEntry: React.FC = () => {
         if(target != null) {
             if(target.name == "image" && target.files != null) {
                 if (target.files[0].size >= urls.CONTENTFUL_IMAGE_LIMIT) {
+<<<<<<< HEAD
                     setFileTooLarge(true);      
                     setTimeout(() => {setFileTooLarge(false)}, 2000);
+=======
+                    // clear past uploaded image and show error 
+                    setImageURL("");
+                    setValues(values => ({...values}));
+                    setFileTooLarge(true);
+>>>>>>> File size checks and modified 404
                     return;
+                }
+                else {
+                    setFileTooLarge(false);      
                 }
                 setValues(values => ({...values, [target.name]: target.files?.item(0)}));
                 handleImageURL(target.files[0]);
@@ -76,6 +91,7 @@ const CreateJournalEntry: React.FC = () => {
     const handleSubmit = async (e: React.SyntheticEvent) => {
         //There's no way to put a required tag on the quill editor, so we just check to make sure there's input in it before submitting.
         e.preventDefault();
+<<<<<<< HEAD
         if (!values.body) {
             setValues({ ...values, ["error"]: true });
         }
@@ -103,6 +119,35 @@ const CreateJournalEntry: React.FC = () => {
             <div className={styles["wrapper"]}>
                 <Link href="/journal">
                     <span className={styles["breadcrumb"]}>
+=======
+        if(!values.body){
+            setValues({...values, ["error"]: true});
+            return;
+        }
+        if (fileTooLarge) return;
+
+        // done error checking, send form to backend
+        const fd = new FormData();
+        let key:string;
+        for(key in values){
+            fd.append(key, values[key]);
+        }
+        const response = await fetch('/api/journal/create', {
+            method: "POST",
+            body: fd,
+        });
+        const data:JSON = await response.json();
+        console.log(data);
+    }
+
+
+
+    return(
+        <section className={styles['container']}>
+            <div className={styles['wrapper']}>
+                <Link href='/journal'>
+                    <a className={styles['breadcrumb']}>
+>>>>>>> File size checks and modified 404
                         <FaArrowLeft />
                         <span> Back to all posts</span>
                     </span>
@@ -119,13 +164,16 @@ const CreateJournalEntry: React.FC = () => {
                         <div className={styles["icon-container"]}>
                             <BiImageAdd className={styles["image-icon"]} />
                         </div>
+<<<<<<< HEAD
                         <input type="file" name="image" className={styles['image-select']} onChange={handleData} required/>
                         {/* <div className={`alert alert-success ${this.state.showingAlert ? 'alert-shown' : 'alert-hidden'}`}> */}
+=======
+                        <input type="file" name="image" className={styles['image-select']} onChange={handleChange} required/>
+>>>>>>> File size checks and modified 404
                         <div>
-                            <a className={styles['icon-container']}> 
-                                <strong>Error!</strong> 
-                                File size is too large, it must be below 20MB.
-                            </a>
+                            {fileTooLarge && (
+                            <span className={styles['error']}> {errors.IMAGE_TOO_LARGE} </span>
+                            )}
                         </div>
                     </div>
                     <div className={styles["text-container"]}>

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,30 +1,60 @@
 import { NextPage } from "next";
 import Head from "next/head";
+import Link from "next/link";
 
 const FourOhFour: NextPage = () => {
   return (
     <div className="container">
       <Head>
-        <title>Mindversity | Page not found</title>
+        <title>Page not found | Mindversity</title>
       </Head>
+      
+      <Link href="/">
+        <span className="logo">
+          <img src="/logo.svg" alt="MindVersity Logo"></img>
+        </span>
+      </Link>
       <h1>404 - Page Not Found</h1>
-      <h2>
-        Return <a href="/">home</a>
-      </h2>
+      <Link href="/">      
+        <button className="ret-home-button">
+          Return Home
+        </button>
+      </Link>
+
       <style jsx>{`
         .container {
-          min-height: 100vh;
+          min-height: 90vh;
           display: flex;
           flex-direction: column;
           justify-content: center;
           align-items: center;
         }
 
-        h1,
-        h2 {
+        h1 {
           font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
             Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue,
             sans-serif;
+          font-size: 40px;
+        }
+
+        .logo {
+          width: 200px;
+          height: 20px;
+        }
+        
+        .ret-home-button{
+          text-align:center;
+          background:#8C69AA;
+          padding: 10px 20px 10px 20px;
+          border-radius: 5px;
+          font-weight:bold;
+          color:white;
+          cursor:pointer;
+          transition: 0.3s ease;
+        }
+        .ret-home-button:hover{
+          filter:brightness(1.2);
+          transform:translateY(-2px);
         }
       `}</style>
     </div>

--- a/pages/api/journal/create.ts
+++ b/pages/api/journal/create.ts
@@ -3,6 +3,7 @@ import formidable from "formidable";
 import { uploadImage, createJournalEntry } from "server/actions/Contentful";
 import { JournalEntry } from "utils/types";
 import errors from "utils/errors";
+import urls from "utils/urls";
 
 //To get formidable to work, bodyParser has to be turned off. Otherwise, the parse request will never end.
 export const config = {
@@ -25,6 +26,10 @@ export default function handler(
                 files: formidable.Files
             ) => {
                 const journalEntry: JournalEntry = fields;
+
+                // check image size, should be less than 20 MB
+                if (files.image.size >= urls.CONTENTFUL_IMAGE_LIMIT)
+                    throw new Error("File size is too large!");
 
                 //In Contentful, Entries store links to Assets (in this case, our Journal Entry images),
                 //so we get the asset ID and url for the JournalEntry's image

--- a/pages/api/journal/create.ts
+++ b/pages/api/journal/create.ts
@@ -29,8 +29,9 @@ export default function handler(
 
                 // check image size, should be less than 20 MB
                 if (files.image.size >= urls.CONTENTFUL_IMAGE_LIMIT)
-                    throw new Error("File size is too large!");
+                    throw new Error(errors.IMAGE_TOO_LARGE);
 
+                    
                 //In Contentful, Entries store links to Assets (in this case, our Journal Entry images),
                 //so we get the asset ID and url for the JournalEntry's image
                 journalEntry.image = await uploadImage(files.image);

--- a/pages/api/officer/addOfficer.ts
+++ b/pages/api/officer/addOfficer.ts
@@ -3,7 +3,11 @@ import { uploadImage } from "server/actions/Contentful";
 import { addOfficer } from "server/actions/Officer";
 import formidable from "formidable";
 import { Officer } from "utils/types";
+<<<<<<< HEAD
 import errors from "utils/errors";
+=======
+import urls from "utils/urls";
+>>>>>>> Working on file to olarge errors
 
 //To get formidable to work, bodyParser has to be turned off.
 // Otherwise, the parse request will never end.
@@ -29,9 +33,15 @@ export default function handler(
                 //Fields is used for everything other than files, so all this data can be passed in directly to the officer type.
                 const officerInfo: Officer = fields;
 
+<<<<<<< HEAD
                 // check image size, should be less than 20 MB
                 if (files.picture.size >= 20 * 1000 * 1000)
                     throw new Error("File size is too large!");
+=======
+            // check image size, should be less than 20 MB
+            if (files.image.size >= urls.CONTENTFUL_IMAGE_LIMIT)
+                throw new Error("File size is too large!");
+>>>>>>> Working on file to olarge errors
 
                 // upload the officer's profile pic to contentful
                 // keep .picture in sync with the front-end input name in the form

--- a/pages/api/officer/addOfficer.ts
+++ b/pages/api/officer/addOfficer.ts
@@ -3,11 +3,8 @@ import { uploadImage } from "server/actions/Contentful";
 import { addOfficer } from "server/actions/Officer";
 import formidable from "formidable";
 import { Officer } from "utils/types";
-<<<<<<< HEAD
-import errors from "utils/errors";
-=======
 import urls from "utils/urls";
->>>>>>> Working on file to olarge errors
+import errors from "utils/errors";
 
 //To get formidable to work, bodyParser has to be turned off.
 // Otherwise, the parse request will never end.
@@ -33,15 +30,9 @@ export default function handler(
                 //Fields is used for everything other than files, so all this data can be passed in directly to the officer type.
                 const officerInfo: Officer = fields;
 
-<<<<<<< HEAD
-                // check image size, should be less than 20 MB
-                if (files.picture.size >= 20 * 1000 * 1000)
-                    throw new Error("File size is too large!");
-=======
             // check image size, should be less than 20 MB
             if (files.image.size >= urls.CONTENTFUL_IMAGE_LIMIT)
-                throw new Error("File size is too large!");
->>>>>>> Working on file to olarge errors
+                throw new Error(errors.IMAGE_TOO_LARGE);
 
                 // upload the officer's profile pic to contentful
                 // keep .picture in sync with the front-end input name in the form

--- a/pages/chapters/index.tsx
+++ b/pages/chapters/index.tsx
@@ -15,7 +15,6 @@ interface Props {
 }
 
 const ChapterPage: NextPage<Props> = ({chapter}) => {
-  console.log(chapter);
   return(
     <div>
 

--- a/server/actions/Contentful.ts
+++ b/server/actions/Contentful.ts
@@ -90,7 +90,8 @@ export async function createJournalEntry(journalEntry: JournalEntry){
         }
     });
 
-    if(!entry)
+    await entry.publish();
+    if(!entry) 
         throw new Error("Error creating journal entry.");
 }
 
@@ -102,7 +103,7 @@ export async function getJournalEntriesByReviewStatus(reviewed: boolean){
     const space = await client.getSpace(process.env.CONTENTFUL_SPACE as string);
     const environment = await space.getEnvironment(process.env.CONTENTFUL_ENVIRONMENT as string);
     const entries = await environment.getEntries({
-        content_type: 'blogPost',
+        'content_type': 'blogPost',
         'fields.reviewed': reviewed,
     });
 
@@ -168,34 +169,28 @@ export async function deleteJournalEntryById(id: string){
     await entry.delete();
 }
 
-
-// todo not sure what this is supposed to do exactly
-// should fetch by type: creative-space, vent-space, or resource
 /**
  * @param type what journal category to filter by: creative-space or vent-place
- * @returns An array of entries containing to the type specified.
+ * @returns An array of *reviewed* entries containing to the type specified. It only
+ * returns the fields that are used in the journal preview. 
  */
 export async function getJournalEntryByType(type: string){
     const space = await client.getSpace(process.env.CONTENTFUL_SPACE as string);
     const environment = await space.getEnvironment(process.env.CONTENTFUL_ENVIRONMENT as string);
     const entries = await environment.getEntries({
-        content_type: 'blogPost',
+        'content_type': 'blogPost',
         'fields.category': type,
+        'fields.reviewed': true,
     });
 
     var journalEntries : JournalEntry[] = [];
     for (var i=0; i < entries.total; i++) {
         var journalEntry: JournalEntry = {};
         journalEntry.id = entries.items[i].sys.id; // unique id for the asset
-        journalEntry.body = entries.items[i].fields.body['en-US'];
         journalEntry.category = entries.items[i].fields.category['en-US'];
         journalEntry.description = entries.items[i].fields.description['en-US'];
         journalEntry.image = entries.items[i].fields.image['en-US'];
         journalEntry.title = entries.items[i].fields.title['en-US'];
-
-        // pass in ISO format and format to: Month Day, Year
-        var date: Date = new Date(entries.items[0].sys.createdAt); 
-        journalEntry.dateCreated = format(date, 'MMMM dd, yyyy');
 
         journalEntries.push(journalEntry);
     }

--- a/utils/errors.ts
+++ b/utils/errors.ts
@@ -1,5 +1,6 @@
 export default {
     GENERIC_ERROR: "An unexpected error occurred.",
+    IMAGE_TOO_LARGE: "Image size is too large, it must be below 20MB.",
     login: {
       INVALID_LOGIN: "Incorrect email or password.",
       USER_EXISTS: "A user with this email already exists.",

--- a/utils/urls.ts
+++ b/utils/urls.ts
@@ -2,6 +2,7 @@ const prod = process.env.NODE_ENV === "production";
 
 export default {
     baseUrl: prod ? (process.env.PROD_URL as string) : "http://localhost:3000",
+    CONTENTFUL_IMAGE_LIMIT: 20*1000*1000, // 20 MB
     dbUrl: process.env.MONGO_DB ?? "mongodb://localhost:27017",
     pages: {
         index: "/",


### PR DESCRIPTION
Changes
-----

- Set 'fields.reviewed': true when querying by type. This way, the public will only see reviewed journals.
- Automatically publish the journals on create. They used to be in drafted before, but now they're auto published and we can filter then by reviewed status or type to get the ones we want.
- Check image size on journal image upload. This shows/clears errors on image upload. It'll clear the previous image and show the error if they've uploaded an image too large.
<img width="1052" alt="image_error" src="https://user-images.githubusercontent.com/37582248/102825885-5171a800-43a5-11eb-9e0d-91f61a881e29.png">

- Also slightly tweaked the error checking of body text of the journal. This is still done on submission, but fixed a bug where an empty body was still sent to backend.
- Modified 404 page
<img width="1272" alt="404" src="https://user-images.githubusercontent.com/37582248/102825894-546c9880-43a5-11eb-8da3-ac927406c85b.png">

Let me know if you guys want any design changes on those front end parts too.
