### PR TITLE
Finished getStaticProps() error handling

### DIFF
--- a/pages/chapters/[name].tsx
+++ b/pages/chapters/[name].tsx
@@ -286,6 +286,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
     } catch (error) {
         return {
             props: {},
+            revalidate: globals.revalidate.chapter,
         };
     }
 }

--- a/pages/chapters/index.tsx
+++ b/pages/chapters/index.tsx
@@ -5,17 +5,26 @@ import { getChapters } from "server/actions/Chapter";
 import { Chapter } from "utils/types";
 import { NextPage, NextPageContext } from "next";
 import Head from "next/head";
-import errors from "utils/errors";
 import globals from "utils/globals";
+import { useRouter } from "next/router";
+import Custom404 from "pages/404";
+import Loading from 'components/Loading';
 
-// When routing here we have a chapter name we can get from the url name
-// We can get that param with useRouter(), but its also given in the context
 
 interface Props {
     chapter: Chapter[];
 }
 
 const ChapterPage: NextPage<Props> = ({ chapter }) => {
+    const router = useRouter();
+    if (router.isFallback) {
+        return <Loading />;
+    }
+
+    if (!chapter) {
+        return <Custom404 />;
+    }
+
     return (
         <div>
             <Head>
@@ -119,16 +128,23 @@ const ChapterPage: NextPage<Props> = ({ chapter }) => {
 
 //Get all of the chapters
 export async function getStaticProps(context: NextPageContext) {
-    //Query to get all of the chapters
-    const chapterQuery: Chapter = new Object();
-    const chapters: Chapter[] = await getChapters(chapterQuery);
-    //Return an array of the chapters
-    return {
-        props: {
-            chapter: JSON.parse(JSON.stringify(chapters)) as Chapter[],
-        },
-        revalidate: globals.revalidate.chapter,
-    };
+    try {
+        //Query to get all of the chapters
+        const chapterQuery: Chapter = new Object();
+        const chapters: Chapter[] = await getChapters(chapterQuery);
+        //Return an array of the chapters
+        return {
+            props: {
+                chapter: JSON.parse(JSON.stringify(chapters)) as Chapter[],
+            },
+            revalidate: globals.revalidate.chapter,
+        };
+    } catch (error) {
+        return {
+            props: {},
+            revalidate: globals.revalidate.chapter,
+        };
+    }
 }
 
 export default ChapterPage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,6 +10,9 @@ import { Officer, Chapter } from "utils/types";
 import { getOfficers } from "server/actions/Officer";
 import { getChapters } from "server/actions/Chapter";
 import globals from "utils/globals";
+import Custom404 from "pages/404";
+import Loading from 'components/Loading';
+import { useRouter } from "next/router";
 
 interface Props {
   officers: Officer[],
@@ -17,6 +20,14 @@ interface Props {
 }
 
 const Home: NextPage<Props> = ({officers,chapters}) => {
+  const router = useRouter();
+  if (router.isFallback) {
+    return <Loading />;
+  }
+
+  if (!officers || !chapters) {
+    return <Custom404 />;
+  }
 
   return (
     <div className="container">
@@ -93,19 +104,26 @@ const Home: NextPage<Props> = ({officers,chapters}) => {
 };
 
 export async function getStaticProps() {
-  let officerQuery: Officer = {chapter: 'national'}
-  let officers: Officer[] = await getOfficers(officerQuery)
+  try {
+    let officerQuery: Officer = {chapter: 'national'}
+    let officers: Officer[] = await getOfficers(officerQuery)
 
-  // Get all chapters. Filter by region in component once user's location is retrieved.
-  // Navigator is undefined in async getStaticProps(), so must do it in component.
-  let chapters: Chapter[] = await getChapters({})
+    // Get all chapters. Filter by region in component once user's location is retrieved.
+    // Navigator is undefined in async getStaticProps(), so must do it in component.
+    let chapters: Chapter[] = await getChapters({})
 
-  return {
-    props: {
-      officers: JSON.parse(JSON.stringify(officers)),
-      chapters: JSON.parse(JSON.stringify(chapters)),
-    },
-    revalidate: globals.revalidate.home,
+    return {
+      props: {
+        officers: JSON.parse(JSON.stringify(officers)),
+        chapters: JSON.parse(JSON.stringify(chapters)),
+      },
+      revalidate: globals.revalidate.home,
+    }
+  } catch (error) {
+    return {
+      props: {},
+      revalidate: globals.revalidate.home,
+    }
   }
 }
 

--- a/pages/journal/index.tsx
+++ b/pages/journal/index.tsx
@@ -9,6 +9,8 @@ import { JournalEntry } from "utils/types";
 import { ChangeEvent, useState } from "react";
 import { getJournalEntryByType } from "server/actions/Contentful";
 import globals from "utils/globals";
+import Custom404 from "pages/404";
+import Loading from 'components/Loading';
 
 const ITEMS_PER_PAGE = 6;
 
@@ -64,7 +66,15 @@ const JournalPage: NextPage<Props> = ({ journalEntries }) => {
         setPagedEntries(tempEntries);
     };
 
-    // console.log(selectedPosts)
+
+    if (router.isFallback) {
+        return <Loading />;
+    }
+
+    if (!journalEntries) {
+        return <Custom404 />;
+    }
+
     return (
         <main className="container">
             <Head>
@@ -292,13 +302,20 @@ const JournalPage: NextPage<Props> = ({ journalEntries }) => {
 };
 
 export async function getStaticProps(context: GetStaticPropsContext) {
-    const data = await getJournalEntryByType("");
-    return {
-        props: {
-            journalEntries: data,
-        },
-        revalidate: globals.revalidate.journal,
-    };
+    try{
+        const data = await getJournalEntryByType("");
+        return {
+            props: {
+                journalEntries: data,
+            },
+            revalidate: globals.revalidate.journal,
+        };
+    } catch (error) {
+        return {
+            props: {},
+            revalidate: globals.revalidate.journal,
+        };
+    }
 }
 
 export default JournalPage;

--- a/pages/portal/resources/index.tsx
+++ b/pages/portal/resources/index.tsx
@@ -168,8 +168,6 @@ export async function getServerSideProps(context: NextPageContext) {
     if (chapter == "admin" || chapter == "national") resources = await getResources({});
     else if (chapter != null) resources = await getResources({ chapter: chapter });
 
-    console.log(resources);
-
     return {
         props: {
             resource: JSON.parse(JSON.stringify(resources)) as Resource[],

--- a/pages/resources/index.tsx
+++ b/pages/resources/index.tsx
@@ -6,6 +6,9 @@ import Footer from "components/Footer";
 import { Resource } from "utils/types";
 import { getResources } from "server/actions/Resource";
 import globals from "utils/globals";
+import Custom404 from "pages/404";
+import Loading from 'components/Loading';
+import { useRouter } from "next/router";
 
 interface Props {
     resources: Resource[];
@@ -61,6 +64,15 @@ const Resources: NextPage<Props> = ({ resources }) => {
     const mindversityLinks = getLinks("mindversity", mindversityCount);
     const helpLinks = getLinks("help", helpCount);
 
+    const router = useRouter();
+    if (router.isFallback) {
+        return <Loading />;
+    }
+    
+    if (!resources) {
+        return <Custom404 />;
+    }
+    
     return (
         <main className="container">
             <Head>
@@ -235,15 +247,22 @@ const Resources: NextPage<Props> = ({ resources }) => {
 };
 
 export async function getStaticProps() {
-    // Get all resources, divide into categories later.
-    const resources: Resource[] = await getResources({ chapter: "national" });
+    try {
+        // Get all resources, divide into categories later.
+        const resources: Resource[] = await getResources({ chapter: "national" });
 
-    return {
-        props: {
-            resources: JSON.parse(JSON.stringify(resources)) as Resource[],
-        },
-        revalidate: globals.revalidate.resources,
-    };
+        return {
+            props: {
+                resources: JSON.parse(JSON.stringify(resources)) as Resource[],
+            },
+            revalidate: globals.revalidate.resources,
+        };
+    } catch(error) {
+        return {
+            props: {},
+            revalidate: globals.revalidate.resources,
+        };
+    }
 }
 
 export default Resources;


### PR DESCRIPTION
This PR finishes error handling all of the getStaticProps() calls. I left everything under the portal directory the same since it looks like there's rerouting done if the user doesn't have permissions or if the fetched data is empty.