### PR TITLE
requests folder and footer changes

### DIFF
--- a/components/Footer/footer.module.scss
+++ b/components/Footer/footer.module.scss
@@ -10,7 +10,7 @@ $background:#B59CCC;
   display: flex;
   flex-direction: column;
   justify-content: center;
-  max-width: 700px;
+  max-width: 900px;
   width: 100%;
   margin: 0 auto;
 }
@@ -20,7 +20,7 @@ $background:#B59CCC;
   grid-gap: 10px;
 }
 .row:nth-of-type(1) { 
-  @media (min-width: 860px) { grid-template-columns: 390px 150px 1fr; }
+  @media (min-width: 860px) { grid-template-columns: 390px 150px 150px 1fr; }
   @media (max-width: 860px) { grid-template-columns: repeat(auto-fill, 1fr); }
 }
 .row:nth-of-type(2) {

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -28,6 +28,7 @@ const Footer: React.FC = () => {
                             <span className={styles.link}>FAQ</span>
                         </Link>
                     </div>
+                    {/*TODO: Possibly remove this column or change hrefs*/}
                     <div className={styles.column}>
                         <p className={styles.title}>Get Involved</p>
                         <span>
@@ -45,18 +46,18 @@ const Footer: React.FC = () => {
                     <div className={styles.column}>
                         <p className={styles.title}>Social Media</p>
                         <span>
-                            <a className={styles.link} href="/">
-                                Facebook
-                            </a>
-                            <a className={styles.link} href="/">
-                                Instagram
-                            </a>
-                            <a className={styles.link} href="/">
-                                Twitter
-                            </a>
-                            <a className={styles.link} href="/">
-                                Spotify
-                            </a>
+                            <Link href="https://www.facebook.com/MindVersed/">
+                                <a target="_blank" className={styles.link}>Facebook</a>
+                            </Link>
+                            <Link href="https://www.instagram.com/mindversityorg/">
+                                <a target="_blank" className={styles.link}>Instagram</a>
+                            </Link>
+                            <Link href="https://twitter.com/MindVersity/media">
+                                <a target="_blank" className={styles.link}>Twitter</a>
+                            </Link>
+                            <Link href="https://open.spotify.com/show/1VDhTv2Y0K180XMf9NY23W?si=HhIdhDlHRU2ZOiiH4WFF9Q">
+                                <a target="_blank" className={styles.link}>Spotify</a>
+                            </Link>
                         </span>
                     </div>
                 </div>

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styles from "./footer.module.scss";
 import Link from "next/link";
+
 const Footer: React.FC = () => {
     return (
         <div className={styles.container}>
@@ -27,7 +28,6 @@ const Footer: React.FC = () => {
                             <span className={styles.link}>FAQ</span>
                         </Link>
                     </div>
-                    {/*TODO: Possibly remove this column*/}
                     <div className={styles.column}>
                         <p className={styles.title}>Get Involved</p>
                         <span>
@@ -39,6 +39,23 @@ const Footer: React.FC = () => {
                             </a>
                             <a className={styles.link} href="/">
                                 Contact Us
+                            </a>
+                        </span>
+                    </div>
+                    <div className={styles.column}>
+                        <p className={styles.title}>Social Media</p>
+                        <span>
+                            <a className={styles.link} href="/">
+                                Facebook
+                            </a>
+                            <a className={styles.link} href="/">
+                                Instagram
+                            </a>
+                            <a className={styles.link} href="/">
+                                Twitter
+                            </a>
+                            <a className={styles.link} href="/">
+                                Spotify
                             </a>
                         </span>
                     </div>

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -47,16 +47,24 @@ const Footer: React.FC = () => {
                         <p className={styles.title}>Social Media</p>
                         <span>
                             <Link href="https://www.facebook.com/MindVersed/">
-                                <a target="_blank" className={styles.link}>Facebook</a>
+                                <a target="_blank" className={styles.link}>
+                                    Facebook
+                                </a>
                             </Link>
                             <Link href="https://www.instagram.com/mindversityorg/">
-                                <a target="_blank" className={styles.link}>Instagram</a>
+                                <a target="_blank" className={styles.link}>
+                                    Instagram
+                                </a>
                             </Link>
                             <Link href="https://twitter.com/MindVersity/media">
-                                <a target="_blank" className={styles.link}>Twitter</a>
+                                <a target="_blank" className={styles.link}>
+                                    Twitter
+                                </a>
                             </Link>
                             <Link href="https://open.spotify.com/show/1VDhTv2Y0K180XMf9NY23W?si=HhIdhDlHRU2ZOiiH4WFF9Q">
-                                <a target="_blank" className={styles.link}>Spotify</a>
+                                <a target="_blank" className={styles.link}>
+                                    Spotify
+                                </a>
                             </Link>
                         </span>
                     </div>

--- a/requests/Chapter.ts
+++ b/requests/Chapter.ts
@@ -1,8 +1,9 @@
 import fetch from "isomorphic-unfetch";
 import { Chapter } from "utils/types";
+import urls from "utils/urls";
 
 export const getChapters = (chapter: Chapter) =>
-    fetch("http://localhost:3000/api/chapter/getChapters", {
+    fetch(`${urls.baseUrl}${urls.api.chapter.get}`, {
         method: "POST",
         mode: "same-origin",
         headers: {
@@ -22,7 +23,7 @@ export const getChapters = (chapter: Chapter) =>
         });
 
 export const addChapter = (chapterFormData: FormData) =>
-    fetch("http://localhost:3000/api/chapter/addChapter", {
+    fetch(`${urls.baseUrl}${urls.api.chapter.add}`, {
         method: "POST",
         mode: "same-origin",
         body: chapterFormData,
@@ -39,7 +40,7 @@ export const addChapter = (chapterFormData: FormData) =>
         });
 
 export const updateChapter = (chapterFormData: FormData) =>
-    fetch("http://localhost:3000/api/chapter/updateChapter", {
+    fetch(`${urls.baseUrl}${urls.api.chapter.update}`, {
         method: "PUT",
         mode: "same-origin",
         body: chapterFormData,

--- a/requests/Journal.ts
+++ b/requests/Journal.ts
@@ -1,4 +1,5 @@
 import fetch from "isomorphic-unfetch";
+import urls from "utils/urls";
 
 // TODO: create api endpoint for paginated entries so we dont have
 // to pull all entries and process on the front end. fine for now
@@ -6,7 +7,7 @@ import fetch from "isomorphic-unfetch";
 
 // assuming we only want to show reviewed entries by default
 export const getEntries = () =>
-    fetch("http://localhost:3000/api/journal/getByReviewStatus?reviewed=true", {
+    fetch(`${urls.baseUrl}${urls.api.journal.getByReviewStatus}?reviewed=true`, {
         method: "GET",
         mode: "same-origin",
         headers: {
@@ -23,7 +24,7 @@ export const getEntries = () =>
 
 export const getEntriesByType = async (type: any) => {
     if (!type) return await getEntries();
-    return fetch(`http://localhost:3000/api/journal/getByType?type=${type}`, {
+    return fetch(`${urls.baseUrl}${urls.api.journal.getByType}?type=${type}`, {
         method: "GET",
         mode: "same-origin",
         headers: {
@@ -40,7 +41,7 @@ export const getEntriesByType = async (type: any) => {
 };
 
 export const getPostById = async (id: any) =>
-    fetch(`http://localhost:3000/api/journal/getById?id=${id}`, {
+    fetch(`${urls.baseUrl}${urls.api.journal.getById}?id=${id}`, {
         method: "GET",
         mode: "same-origin",
         headers: {

--- a/requests/Officer.ts
+++ b/requests/Officer.ts
@@ -1,8 +1,9 @@
 import fetch from "isomorphic-unfetch";
 import { Officer } from "utils/types";
+import urls from "utils/urls";
 
 export const getOfficers = (officer: Officer) =>
-    fetch("http://localhost:3000/api/officer/getOfficers", {
+    fetch(`${urls.baseUrl}${urls.api.officer.get}`, {
         method: "POST",
         mode: "same-origin",
         headers: {
@@ -22,7 +23,7 @@ export const getOfficers = (officer: Officer) =>
         });
 
 export const addOfficer = (form: FormData) =>
-    fetch("http://localhost:3000/api/officer/addOfficer", {
+    fetch(`${urls.baseUrl}${urls.api.officer.add}`, {
         method: "POST",
         mode: "same-origin",
         body: form,
@@ -39,7 +40,7 @@ export const addOfficer = (form: FormData) =>
         });
 
 export const deleteOfficer = (officer: Officer) =>
-    fetch("http://localhost:3000/api/officer/deleteOfficer", {
+    fetch(`${urls.baseUrl}${urls.api.officer.delete}`, {
         method: "POST",
         mode: "same-origin",
         body: JSON.stringify(officer),

--- a/requests/Resource.ts
+++ b/requests/Resource.ts
@@ -1,8 +1,9 @@
 import fetch from "isomorphic-unfetch";
 import { Resource } from "utils/types";
+import urls from "utils/urls";
 
 export const getResources = async (resource: Resource) =>
-    fetch("http://localhost:3000/api/resource/getResource", {
+    fetch(`${urls.baseUrl}${urls.api.resource.get}`, {
         method: "POST",
         mode: "same-origin",
         headers: {
@@ -22,7 +23,7 @@ export const getResources = async (resource: Resource) =>
         });
 
 export const addResources = async (resource: Resource) => {
-    fetch("http://localhost:3000/api/resource/addResource", {
+    fetch(`${urls.baseUrl}${urls.api.resource.add}`, {
         method: "POST",
         mode: "same-origin",
         headers: {
@@ -42,7 +43,7 @@ export const addResources = async (resource: Resource) => {
         });
 };
 export const deleteResources = async (resource: Resource) => {
-    fetch("http://localhost:3000/api/resource/deleteResource", {
+    fetch(`${urls.baseUrl}${urls.api.resource.delete}`, {
         method: "POST",
         mode: "same-origin",
         headers: {
@@ -63,7 +64,7 @@ export const deleteResources = async (resource: Resource) => {
 };
 
 export const updateResources = async (resource: Resource) => {
-    fetch("http://localhost:3000/api/resource/updateResource", {
+    fetch(`${urls.baseUrl}${urls.api.resource.update}`, {
         method: "POST",
         mode: "same-origin",
         headers: {

--- a/server/actions/User.ts
+++ b/server/actions/User.ts
@@ -126,7 +126,7 @@ export async function sendForgotPasswordEmail(email: string): Promise<void> {
         from: "mvpassreset@gmail.com",
         to: email,
         subject: "MindVersity Admin Password Reset",
-        text: `Click this link to reset your MindVeristy Admin password:\n${baseURL}/${urls.pages.portal.newPassword}?email=${email}&key=${randomHash}`,
+        text: `Click this link to reset your MindVeristy Admin password:\n${baseURL}${urls.pages.portal.newPassword}?email=${email}&key=${randomHash}`,
     };
 
     void transporter.sendMail(mailOptions);

--- a/utils/urls.ts
+++ b/utils/urls.ts
@@ -12,8 +12,8 @@ export default {
         portal: {
             login: "/portal",
             dashboard: "/portal/dashboard",
-            passwordReset: "portal/password-reset",
-            newPassword: "portal/new-password",
+            passwordReset: "/portal/password-reset",
+            newPassword: "/portal/new-password",
         },
     },
     api: {
@@ -25,15 +25,13 @@ export default {
             validateLogin: "/api/admin/validateLogin",
             signout: "/api/admin/signout",
         },
-        blog: {
-            get: "/api/blog/getBlog",
-        },
         chapter: {
             add: "/api/chapter/addChapter",
-            get: "/api/chapter/getChapter",
+            get: "/api/chapter/getChapters",
             update: "/api/chapter/updateChapter",
         },
         officer: {
+            add: "/api/officer/addOfficer",
             get: "/api/officer/getOfficers",
             delete: "/api/officer/deleteOfficer",
         },
@@ -43,5 +41,10 @@ export default {
             update: "/api/resource/updateResource",
             delete: "/api/resource/deleteResource",
         },
+        journal: {
+            getByType: "/api/journal/getByType",
+            getById: "/api/journal/getById",
+            getByReviewStatus: "/api/journal/getByReviewStatus",
+        }, 
     },
 };

--- a/utils/urls.ts
+++ b/utils/urls.ts
@@ -45,6 +45,6 @@ export default {
             getByType: "/api/journal/getByType",
             getById: "/api/journal/getById",
             getByReviewStatus: "/api/journal/getByReviewStatus",
-        }, 
+        },
     },
 };


### PR DESCRIPTION
Two pretty small changes:
1. All of the fetch calls in the requests folder are now "baseUrl + api endpoint" in case the endpoints change. It references them from utils/urls.ts.
2. Add social media into footer. It now looks like:
<img width="1280" alt="Screen Shot 2020-12-25 at 12 28 42 AM" src="https://user-images.githubusercontent.com/37582248/103123259-61111b00-4649-11eb-8686-e376bce7ffdf.png">
<img width="644" alt="Screen Shot 2020-12-25 at 12 29 45 AM" src="https://user-images.githubusercontent.com/37582248/103123261-61a9b180-4649-11eb-9ca9-b6f71eae5bba.png">


