### PR TITLE
Implements checking for phone numbers in resources

### DIFF
--- a/pages/chapters/[name].tsx
+++ b/pages/chapters/[name].tsx
@@ -36,7 +36,16 @@ const ChapterPage: NextPage<Props> = ({ chapter, officers, resources }) => {
     //Replace any underscores in the chapter name with spaces
     const cleanName = chapter.name?.replace(/_/g, " ");
     //Make the first letter of the region name capital
-
+    
+    //Used to make phone number resources link correctly.
+    const isPhoneNumber = (resource: string):boolean => {
+        //Check to see if the resource is a phone number
+        let regExp = /^(\+\d{1,2}\s)?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}$/;
+        if(resource.match(regExp)){
+            return true;
+        }
+        return false;
+    };
     let heroStyle;
     if (chapter.campusPic?.url) {
         //Add the background image to the style if the url exists in the db
@@ -91,7 +100,7 @@ const ChapterPage: NextPage<Props> = ({ chapter, officers, resources }) => {
                                 {resources.map((reso, i) => {
                                     return (
                                         <p className="resourceTextStyle" key={i}>
-                                            <a className="resourceLinkStyle" href={reso.link}>
+                                            <a className="resourceLinkStyle" href={isPhoneNumber(reso.link as string) ? `tel:${reso.link}`: reso.link}>
                                                 {reso.name}
                                             </a>
                                         </p>

--- a/pages/resources/index.tsx
+++ b/pages/resources/index.tsx
@@ -48,11 +48,19 @@ const Resources: NextPage<Props> = ({ resources }) => {
             textDecoration: "none",
             color: "#000000",
         };
+        const isPhoneNumber = (resource: string):boolean => {
+            //Check to see if the resource is a phone number
+            let regExp = /^(\+\d{1,2}\s)?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}$/;
+            if(resource.match(regExp)){
+                return true;
+            }
+            return false;
+        };
 
         // Links elements
         return links.map(link => (
             <p style={textStyle} key={category + (link.link as string)}>
-                <a style={linkStyle} href={link.link}>
+                <a style={linkStyle} href={isPhoneNumber(link.link as string) ? `tel:${link.link}`: link.link}>
                     {link.name}
                 </a>
             </p>


### PR DESCRIPTION
This small PR adds in some checks for phone number resources in `/resources` and `/chapter/[name]`. If a resource is detected to be a number, then "tel:" is added before it. 

Please let me know if I need to change anything.